### PR TITLE
Add missing scheme registration and rbac in controller manager

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 
 	computev1alpha1 "github.com/onmetal/onmetal-api/apis/compute/v1alpha1"
 	ipamv1alpha1 "github.com/onmetal/onmetal-api/apis/ipam/v1alpha1"
+	networkingv1alpha1 "github.com/onmetal/onmetal-api/apis/networking/v1alpha1"
 	storagev1alpha1 "github.com/onmetal/onmetal-api/apis/storage/v1alpha1"
 	computecontrollers "github.com/onmetal/onmetal-api/controllers/compute"
 	ipamcontrollers "github.com/onmetal/onmetal-api/controllers/ipam"
@@ -81,6 +82,7 @@ func init() {
 	utilruntime.Must(storagev1alpha1.AddToScheme(scheme))
 	utilruntime.Must(networkingv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(ipamv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(networkingv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
# Proposed Changes

The controller manager was missing the scheme registration for the
`networkging` group. ~Further more the `NetworkInterface` controller
was missing the markes for correct RBAC manifest generation.~

/cc @nikhilbarge 