### PR TITLE
Machine image pull secrets

### DIFF
--- a/apis/compute/machine_types.go
+++ b/apis/compute/machine_types.go
@@ -35,6 +35,8 @@ type MachineSpec struct {
 	MachinePoolRef *corev1.LocalObjectReference
 	// Image is the URL providing the operating system image of the machine.
 	Image string
+	// ImagePullSecretRef is an optional secret for pulling the image of a machine.
+	ImagePullSecretRef *corev1.LocalObjectReference
 	// NetworkInterfaces define a list of network interfaces present on the machine
 	NetworkInterfaces []NetworkInterface
 	// Volumes are volumes attached to this machine.

--- a/apis/compute/v1alpha1/machine_types.go
+++ b/apis/compute/v1alpha1/machine_types.go
@@ -35,6 +35,8 @@ type MachineSpec struct {
 	MachinePoolRef *corev1.LocalObjectReference `json:"machinePoolRef,omitempty"`
 	// Image is the URL providing the operating system image of the machine.
 	Image string `json:"image"`
+	// ImagePullSecretRef is an optional secret for pulling the image of a machine.
+	ImagePullSecretRef *corev1.LocalObjectReference `json:"imagePullSecret,omitempty"`
 	// NetworkInterfaces define a list of network interfaces present on the machine
 	NetworkInterfaces []NetworkInterface `json:"networkInterfaces,omitempty"`
 	// Volumes are volumes attached to this machine.

--- a/apis/compute/v1alpha1/zz_generated.conversion.go
+++ b/apis/compute/v1alpha1/zz_generated.conversion.go
@@ -580,6 +580,7 @@ func autoConvert_v1alpha1_MachineSpec_To_compute_MachineSpec(in *MachineSpec, ou
 	out.MachinePoolSelector = *(*map[string]string)(unsafe.Pointer(&in.MachinePoolSelector))
 	out.MachinePoolRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.MachinePoolRef))
 	out.Image = in.Image
+	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.NetworkInterfaces = *(*[]compute.NetworkInterface)(unsafe.Pointer(&in.NetworkInterfaces))
 	out.Volumes = *(*[]compute.Volume)(unsafe.Pointer(&in.Volumes))
 	out.IgnitionRef = (*commonv1alpha1.ConfigMapKeySelector)(unsafe.Pointer(in.IgnitionRef))
@@ -598,6 +599,7 @@ func autoConvert_compute_MachineSpec_To_v1alpha1_MachineSpec(in *compute.Machine
 	out.MachinePoolSelector = *(*map[string]string)(unsafe.Pointer(&in.MachinePoolSelector))
 	out.MachinePoolRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.MachinePoolRef))
 	out.Image = in.Image
+	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.NetworkInterfaces = *(*[]NetworkInterface)(unsafe.Pointer(&in.NetworkInterfaces))
 	out.Volumes = *(*[]Volume)(unsafe.Pointer(&in.Volumes))
 	out.IgnitionRef = (*commonv1alpha1.ConfigMapKeySelector)(unsafe.Pointer(in.IgnitionRef))

--- a/apis/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/compute/v1alpha1/zz_generated.deepcopy.go
@@ -372,6 +372,11 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
+	if in.ImagePullSecretRef != nil {
+		in, out := &in.ImagePullSecretRef, &out.ImagePullSecretRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
 		*out = make([]NetworkInterface, len(*in))

--- a/apis/compute/validation/machine.go
+++ b/apis/compute/validation/machine.go
@@ -71,6 +71,12 @@ func validateMachineSpec(machineSpec *compute.MachineSpec, fldPath *field.Path) 
 		}
 	}
 
+	if machineSpec.ImagePullSecretRef != nil {
+		for _, msg := range apivalidation.NameIsDNSLabel(machineSpec.ImagePullSecretRef.Name, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("imagePullSecretRef").Child("name"), machineSpec.ImagePullSecretRef.Name, msg))
+		}
+	}
+
 	seenNames := sets.NewString()
 	for i, vol := range machineSpec.Volumes {
 		if seenNames.Has(vol.Name) {

--- a/apis/compute/validation/machine_test.go
+++ b/apis/compute/validation/machine_test.go
@@ -121,6 +121,16 @@ var _ = Describe("Machine", func() {
 			},
 			ContainElement(InvalidField("spec.ignitionRef.name")),
 		),
+		Entry("invalid ignition ref name",
+			&compute.Machine{
+				Spec: compute.MachineSpec{
+					ImagePullSecretRef: &corev1.LocalObjectReference{
+						Name: "foo*",
+					},
+				},
+			},
+			ContainElement(InvalidField("spec.imagePullSecretRef.name")),
+		),
 	)
 
 	DescribeTable("ValidateMachineUpdate",

--- a/apis/compute/zz_generated.deepcopy.go
+++ b/apis/compute/zz_generated.deepcopy.go
@@ -372,6 +372,11 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
+	if in.ImagePullSecretRef != nil {
+		in, out := &in.ImagePullSecretRef, &out.ImagePullSecretRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
 		*out = make([]NetworkInterface, len(*in))

--- a/docs/api-reference/compute.md
+++ b/docs/api-reference/compute.md
@@ -124,6 +124,19 @@ string
 </tr>
 <tr>
 <td>
+<code>imagePullSecret</code><br/>
+<em>
+<a href="https://v1-23.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>ImagePullSecretRef is an optional secret for pulling the image of a machine.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>networkInterfaces</code><br/>
 <em>
 <a href="#compute.api.onmetal.de/v1alpha1.NetworkInterface">
@@ -875,6 +888,19 @@ string
 </td>
 <td>
 <p>Image is the URL providing the operating system image of the machine.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullSecret</code><br/>
+<em>
+<a href="https://v1-23.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>ImagePullSecretRef is an optional secret for pulling the image of a machine.</p>
 </td>
 </tr>
 <tr>

--- a/generated/openapi/api_violations.report
+++ b/generated/openapi/api_violations.report
@@ -141,6 +141,7 @@ API rule violation: list_type_missing,k8s.io/apimachinery/pkg/apis/meta/v1,Table
 API rule violation: list_type_missing,k8s.io/apimachinery/pkg/apis/meta/v1,UpdateOptions,DryRun
 API rule violation: list_type_missing,k8s.io/apimachinery/pkg/runtime,RawExtension,Raw
 API rule violation: list_type_missing,k8s.io/apimachinery/pkg/runtime,Unknown,Raw
+API rule violation: names_match,github.com/onmetal/onmetal-api/apis/compute/v1alpha1,MachineSpec,ImagePullSecretRef
 API rule violation: names_match,github.com/onmetal/onmetal-api/apis/compute/v1alpha1,NetworkInterfaceStatus,IPs
 API rule violation: names_match,github.com/onmetal/onmetal-api/apis/networking/v1alpha1,NetworkInterfaceSpec,IPs
 API rule violation: names_match,github.com/onmetal/onmetal-api/apis/networking/v1alpha1,NetworkInterfaceSpec,VirtualIP

--- a/generated/openapi/zz_generated.openapi.go
+++ b/generated/openapi/zz_generated.openapi.go
@@ -1211,6 +1211,12 @@ func schema_onmetal_api_apis_compute_v1alpha1_MachineSpec(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"imagePullSecret": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ImagePullSecretRef is an optional secret for pulling the image of a machine.",
+							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
+						},
+					},
 					"networkInterfaces": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NetworkInterfaces define a list of network interfaces present on the machine",


### PR DESCRIPTION
Introduce `Machine.Spec.ImagePullSecret` for optionally specifying a
secret to authenticate with to the OCI registry for pulling a machine's
image.

Fixes #240 

cc @gehoern 