### PR TITLE
Support volume image / image pull secret

### DIFF
--- a/apis/storage/v1alpha1/volume_types.go
+++ b/apis/storage/v1alpha1/volume_types.go
@@ -42,6 +42,10 @@ type VolumeSpec struct {
 	ClaimRef *commonv1alpha1.LocalUIDReference `json:"claimRef,omitempty"`
 	// Resources is a description of the volume's resources and capacity.
 	Resources corev1.ResourceList `json:"resources,omitempty"`
+	// Image is an optional image to bootstrap the volume with.
+	Image string `json:"image,omitempty"`
+	// ImagePullSecretRef is an optional secret for pulling the image of a volume.
+	ImagePullSecretRef *corev1.LocalObjectReference `json:"imagePullSecretRef,omitempty"`
 	// Tolerations define tolerations the Volume has. Only any VolumePool whose taints
 	// covered by Tolerations will be considered to host the Volume.
 	Tolerations []commonv1alpha1.Toleration `json:"tolerations,omitempty"`

--- a/apis/storage/v1alpha1/volumeclaim_types.go
+++ b/apis/storage/v1alpha1/volumeclaim_types.go
@@ -36,6 +36,10 @@ type VolumeClaimSpec struct {
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 	// Resources are the requested Volume resources.
 	Resources corev1.ResourceList `json:"resources"`
+	// Image is an optional image to bootstrap the volume with.
+	Image string `json:"image,omitempty"`
+	// ImagePullSecretRef is an optional secret for pulling the image of a volume.
+	ImagePullSecretRef *corev1.LocalObjectReference `json:"imagePullSecretRef,omitempty"`
 	// VolumeClassRef references the VolumeClass used by the Volume.
 	VolumeClassRef corev1.LocalObjectReference `json:"volumeClassRef"`
 }

--- a/apis/storage/v1alpha1/zz_generated.conversion.go
+++ b/apis/storage/v1alpha1/zz_generated.conversion.go
@@ -315,6 +315,8 @@ func autoConvert_v1alpha1_VolumeClaimSpec_To_storage_VolumeClaimSpec(in *VolumeC
 	out.VolumeRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.VolumeRef))
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	out.Resources = *(*v1.ResourceList)(unsafe.Pointer(&in.Resources))
+	out.Image = in.Image
+	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.VolumeClassRef = in.VolumeClassRef
 	return nil
 }
@@ -328,6 +330,8 @@ func autoConvert_storage_VolumeClaimSpec_To_v1alpha1_VolumeClaimSpec(in *storage
 	out.VolumeRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.VolumeRef))
 	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	out.Resources = *(*v1.ResourceList)(unsafe.Pointer(&in.Resources))
+	out.Image = in.Image
+	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.VolumeClassRef = in.VolumeClassRef
 	return nil
 }
@@ -563,6 +567,8 @@ func autoConvert_v1alpha1_VolumeSpec_To_storage_VolumeSpec(in *VolumeSpec, out *
 	out.VolumePoolRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.VolumePoolRef))
 	out.ClaimRef = (*commonv1alpha1.LocalUIDReference)(unsafe.Pointer(in.ClaimRef))
 	out.Resources = *(*v1.ResourceList)(unsafe.Pointer(&in.Resources))
+	out.Image = in.Image
+	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.Tolerations = *(*[]commonv1alpha1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	return nil
 }
@@ -578,6 +584,8 @@ func autoConvert_storage_VolumeSpec_To_v1alpha1_VolumeSpec(in *storage.VolumeSpe
 	out.VolumePoolRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.VolumePoolRef))
 	out.ClaimRef = (*commonv1alpha1.LocalUIDReference)(unsafe.Pointer(in.ClaimRef))
 	out.Resources = *(*v1.ResourceList)(unsafe.Pointer(&in.Resources))
+	out.Image = in.Image
+	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.Tolerations = *(*[]commonv1alpha1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	return nil
 }

--- a/apis/storage/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/storage/v1alpha1/zz_generated.deepcopy.go
@@ -164,6 +164,11 @@ func (in *VolumeClaimSpec) DeepCopyInto(out *VolumeClaimSpec) {
 			(*out)[key] = val.DeepCopy()
 		}
 	}
+	if in.ImagePullSecretRef != nil {
+		in, out := &in.ImagePullSecretRef, &out.ImagePullSecretRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	out.VolumeClassRef = in.VolumeClassRef
 	return
 }
@@ -461,6 +466,11 @@ func (in *VolumeSpec) DeepCopyInto(out *VolumeSpec) {
 		for key, val := range *in {
 			(*out)[key] = val.DeepCopy()
 		}
+	}
+	if in.ImagePullSecretRef != nil {
+		in, out := &in.ImagePullSecretRef, &out.ImagePullSecretRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
 	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations

--- a/apis/storage/validation/volume.go
+++ b/apis/storage/validation/volume.go
@@ -32,35 +32,41 @@ func ValidateVolume(volume *storage.Volume) field.ErrorList {
 	return allErrs
 }
 
-func validateVolumeSpec(volumeSpec *storage.VolumeSpec, fldPath *field.Path) field.ErrorList {
+func validateVolumeSpec(spec *storage.VolumeSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if volumeSpec.VolumeClassRef == (corev1.LocalObjectReference{}) {
+	if spec.VolumeClassRef == (corev1.LocalObjectReference{}) {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volumeClassRef"), "must specify a volume class ref"))
 	}
-	for _, msg := range apivalidation.NameIsDNSLabel(volumeSpec.VolumeClassRef.Name, false) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("volumeClassRef").Child("name"), volumeSpec.VolumeClassRef.Name, msg))
+	for _, msg := range apivalidation.NameIsDNSLabel(spec.VolumeClassRef.Name, false) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("volumeClassRef").Child("name"), spec.VolumeClassRef.Name, msg))
 	}
 
-	allErrs = append(allErrs, metav1validation.ValidateLabels(volumeSpec.VolumePoolSelector, fldPath.Child("volumePoolSelector"))...)
+	allErrs = append(allErrs, metav1validation.ValidateLabels(spec.VolumePoolSelector, fldPath.Child("volumePoolSelector"))...)
 
-	if volumeSpec.VolumePoolRef != nil {
-		for _, msg := range apivalidation.NameIsDNSLabel(volumeSpec.VolumePoolRef.Name, false) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("volumePoolRef").Child("name"), volumeSpec.VolumePoolRef.Name, msg))
+	if spec.VolumePoolRef != nil {
+		for _, msg := range apivalidation.NameIsDNSLabel(spec.VolumePoolRef.Name, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("volumePoolRef").Child("name"), spec.VolumePoolRef.Name, msg))
 		}
 	}
 
-	if volumeSpec.ClaimRef != nil {
-		for _, msg := range apivalidation.NameIsDNSLabel(volumeSpec.ClaimRef.Name, false) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("claimRef").Child("name"), volumeSpec.ClaimRef.Name, msg))
+	if spec.ClaimRef != nil {
+		for _, msg := range apivalidation.NameIsDNSLabel(spec.ClaimRef.Name, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("claimRef").Child("name"), spec.ClaimRef.Name, msg))
 		}
 	}
 
-	storageValue, ok := volumeSpec.Resources[corev1.ResourceStorage]
+	storageValue, ok := spec.Resources[corev1.ResourceStorage]
 	if !ok {
 		allErrs = append(allErrs, field.Required(fldPath.Child("resources").Key(string(corev1.ResourceStorage)), ""))
 	} else {
 		allErrs = append(allErrs, onmetalapivalidation.ValidatePositiveQuantity(storageValue, fldPath.Child("resources").Key(string(corev1.ResourceStorage)))...)
+	}
+
+	if spec.ImagePullSecretRef != nil {
+		for _, msg := range apivalidation.NameIsDNSLabel(spec.ImagePullSecretRef.Name, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("imagePullSecretRef").Child("name"), spec.ImagePullSecretRef.Name, msg))
+		}
 	}
 
 	return allErrs

--- a/apis/storage/validation/volume_test.go
+++ b/apis/storage/validation/volume_test.go
@@ -65,6 +65,14 @@ var _ = Describe("Volume", func() {
 			},
 			ContainElement(InvalidField("spec.claimRef.name")),
 		),
+		Entry("invalid image pull secret ref name",
+			&storage.Volume{
+				Spec: storage.VolumeSpec{
+					ImagePullSecretRef: &corev1.LocalObjectReference{Name: "foo*"},
+				},
+			},
+			ContainElement(InvalidField("spec.imagePullSecretRef.name")),
+		),
 		Entry("no resources[storage]",
 			&storage.Volume{},
 			ContainElement(RequiredField("spec.resources[storage]")),

--- a/apis/storage/validation/volumeclaim.go
+++ b/apis/storage/validation/volumeclaim.go
@@ -32,29 +32,35 @@ func ValidateVolumeClaim(volumeClaim *storage.VolumeClaim) field.ErrorList {
 	return allErrs
 }
 
-func validateVolumeClaimSpec(volumeClaimSpec *storage.VolumeClaimSpec, fldPath *field.Path) field.ErrorList {
+func validateVolumeClaimSpec(spec *storage.VolumeClaimSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if volumeClaimSpec.VolumeClassRef == (corev1.LocalObjectReference{}) {
+	if spec.VolumeClassRef == (corev1.LocalObjectReference{}) {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volumeClassRef"), "must specify a volume class ref"))
 	}
-	for _, msg := range apivalidation.NameIsDNSLabel(volumeClaimSpec.VolumeClassRef.Name, false) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("volumeClassRef").Child("name"), volumeClaimSpec.VolumeClassRef.Name, msg))
+	for _, msg := range apivalidation.NameIsDNSLabel(spec.VolumeClassRef.Name, false) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("volumeClassRef").Child("name"), spec.VolumeClassRef.Name, msg))
 	}
 
-	allErrs = append(allErrs, metav1validation.ValidateLabelSelector(volumeClaimSpec.Selector, fldPath.Child("selector"))...)
+	allErrs = append(allErrs, metav1validation.ValidateLabelSelector(spec.Selector, fldPath.Child("selector"))...)
 
-	if volumeClaimSpec.VolumeRef != nil {
-		for _, msg := range apivalidation.NameIsDNSLabel(volumeClaimSpec.VolumeRef.Name, false) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("volumeRef").Child("name"), volumeClaimSpec.VolumeRef.Name, msg))
+	if spec.VolumeRef != nil {
+		for _, msg := range apivalidation.NameIsDNSLabel(spec.VolumeRef.Name, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("volumeRef").Child("name"), spec.VolumeRef.Name, msg))
 		}
 	}
 
-	storageValue, ok := volumeClaimSpec.Resources[corev1.ResourceStorage]
+	storageValue, ok := spec.Resources[corev1.ResourceStorage]
 	if !ok {
 		allErrs = append(allErrs, field.Required(fldPath.Child("resources").Key(string(corev1.ResourceStorage)), ""))
 	} else {
 		allErrs = append(allErrs, onmetalapivalidation.ValidatePositiveQuantity(storageValue, fldPath.Child("resources").Key(string(corev1.ResourceStorage)))...)
+	}
+
+	if spec.ImagePullSecretRef != nil {
+		for _, msg := range apivalidation.NameIsDNSLabel(spec.ImagePullSecretRef.Name, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("imagePullSecretRef").Child("name"), spec.ImagePullSecretRef.Name, msg))
+		}
 	}
 
 	return allErrs

--- a/apis/storage/validation/volumeclaim_test.go
+++ b/apis/storage/validation/volumeclaim_test.go
@@ -56,6 +56,14 @@ var _ = Describe("VolumeClaim", func() {
 			},
 			ContainElement(InvalidField("spec.volumeClassRef.name")),
 		),
+		Entry("invalid image pull secret ref name",
+			&storage.VolumeClaim{
+				Spec: storage.VolumeClaimSpec{
+					ImagePullSecretRef: &corev1.LocalObjectReference{Name: "foo*"},
+				},
+			},
+			ContainElement(InvalidField("spec.imagePullSecretRef.name")),
+		),
 		Entry("invalid volume ref name",
 			&storage.VolumeClaim{
 				Spec: storage.VolumeClaimSpec{

--- a/apis/storage/volume_types.go
+++ b/apis/storage/volume_types.go
@@ -42,6 +42,10 @@ type VolumeSpec struct {
 	ClaimRef *commonv1alpha1.LocalUIDReference
 	// Resources is a description of the volume's resources and capacity.
 	Resources corev1.ResourceList
+	// Image is an optional image to bootstrap the volume with.
+	Image string
+	// ImagePullSecretRef is an optional secret for pulling the image of a volume.
+	ImagePullSecretRef *corev1.LocalObjectReference
 	// Tolerations define tolerations the Volume has. Only a VolumePool whose taints
 	// covered by Tolerations will be considered to host the Volume.
 	Tolerations []commonv1alpha1.Toleration

--- a/apis/storage/volumeclaim_types.go
+++ b/apis/storage/volumeclaim_types.go
@@ -36,6 +36,10 @@ type VolumeClaimSpec struct {
 	Selector *metav1.LabelSelector
 	// Resources are the requested Volume resources.
 	Resources corev1.ResourceList
+	// Image is an optional image to bootstrap the volume with.
+	Image string
+	// ImagePullSecretRef is an optional secret for pulling the image of a volume.
+	ImagePullSecretRef *corev1.LocalObjectReference
 	// VolumeClassRef references the VolumeClass used by the Volume.
 	VolumeClassRef corev1.LocalObjectReference
 }

--- a/apis/storage/zz_generated.deepcopy.go
+++ b/apis/storage/zz_generated.deepcopy.go
@@ -164,6 +164,11 @@ func (in *VolumeClaimSpec) DeepCopyInto(out *VolumeClaimSpec) {
 			(*out)[key] = val.DeepCopy()
 		}
 	}
+	if in.ImagePullSecretRef != nil {
+		in, out := &in.ImagePullSecretRef, &out.ImagePullSecretRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	out.VolumeClassRef = in.VolumeClassRef
 	return
 }
@@ -461,6 +466,11 @@ func (in *VolumeSpec) DeepCopyInto(out *VolumeSpec) {
 		for key, val := range *in {
 			(*out)[key] = val.DeepCopy()
 		}
+	}
+	if in.ImagePullSecretRef != nil {
+		in, out := &in.ImagePullSecretRef, &out.ImagePullSecretRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
 	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations

--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -139,6 +139,30 @@ Kubernetes core/v1.ResourceList
 </tr>
 <tr>
 <td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Image is an optional image to bootstrap the volume with.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullSecretRef</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>ImagePullSecretRef is an optional secret for pulling the image of a volume.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>tolerations</code><br/>
 <em>
 <a href="/api-reference/common/#common.onmetal.de/v1alpha1.Toleration">
@@ -262,6 +286,30 @@ Kubernetes core/v1.ResourceList
 </td>
 <td>
 <p>Resources are the requested Volume resources.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Image is an optional image to bootstrap the volume with.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullSecretRef</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>ImagePullSecretRef is an optional secret for pulling the image of a volume.</p>
 </td>
 </tr>
 <tr>
@@ -585,6 +633,30 @@ Kubernetes core/v1.ResourceList
 </td>
 <td>
 <p>Resources are the requested Volume resources.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Image is an optional image to bootstrap the volume with.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullSecretRef</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>ImagePullSecretRef is an optional secret for pulling the image of a volume.</p>
 </td>
 </tr>
 <tr>
@@ -979,6 +1051,30 @@ Kubernetes core/v1.ResourceList
 </td>
 <td>
 <p>Resources is a description of the volume&rsquo;s resources and capacity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Image is an optional image to bootstrap the volume with.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullSecretRef</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>ImagePullSecretRef is an optional secret for pulling the image of a volume.</p>
 </td>
 </tr>
 <tr>

--- a/generated/openapi/zz_generated.openapi.go
+++ b/generated/openapi/zz_generated.openapi.go
@@ -3050,6 +3050,19 @@ func schema_onmetal_api_apis_storage_v1alpha1_VolumeClaimSpec(ref common.Referen
 							},
 						},
 					},
+					"image": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Image is an optional image to bootstrap the volume with.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"imagePullSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ImagePullSecretRef is an optional secret for pulling the image of a volume.",
+							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
+						},
+					},
 					"volumeClassRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "VolumeClassRef references the VolumeClass used by the Volume.",
@@ -3563,6 +3576,19 @@ func schema_onmetal_api_apis_storage_v1alpha1_VolumeSpec(ref common.ReferenceCal
 									},
 								},
 							},
+						},
+					},
+					"image": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Image is an optional image to bootstrap the volume with.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"imagePullSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ImagePullSecretRef is an optional secret for pulling the image of a volume.",
+							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 						},
 					},
 					"tolerations": {


### PR DESCRIPTION
This allows a volume to be bootstrapped by specifying an image.
Additionally, an image pull secret can be used to authenticate to the
remote OCI registry.

Fixes #341

cc @gehoern 