### PR TITLE
Make `Machine.Spec.Image` optional

### DIFF
--- a/apis/compute/validation/machine.go
+++ b/apis/compute/validation/machine.go
@@ -92,10 +92,6 @@ func validateMachineSpec(machineSpec *compute.MachineSpec, fldPath *field.Path) 
 		allErrs = append(allErrs, validateVolumeSource(&vol.VolumeSource, fldPath.Child("volume").Index(i))...)
 	}
 
-	if machineSpec.Image == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("image"), "must specify an image"))
-	}
-
 	allErrs = append(allErrs, metav1validation.ValidateLabels(machineSpec.MachinePoolSelector, fldPath.Child("machinePoolSelector"))...)
 
 	return allErrs

--- a/apis/compute/validation/machine_test.go
+++ b/apis/compute/validation/machine_test.go
@@ -55,6 +55,10 @@ var _ = Describe("Machine", func() {
 			&compute.Machine{},
 			ContainElement(RequiredField("spec.machineClassRef")),
 		),
+		Entry("no image",
+			&compute.Machine{},
+			Not(ContainElement(RequiredField("spec.image"))),
+		),
 		Entry("invalid machine class ref name",
 			&compute.Machine{
 				Spec: compute.MachineSpec{

--- a/registry/compute/machine/storage/tableconvertor.go
+++ b/registry/compute/machine/storage/tableconvertor.go
@@ -63,6 +63,11 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 
 		cells = append(cells, name)
 		cells = append(cells, machine.Spec.MachineClassRef.Name)
+		if image := machine.Spec.Image; image != "" {
+			cells = append(cells, image)
+		} else {
+			cells = append(cells, "<none>")
+		}
 		cells = append(cells, machine.Spec.Image)
 		if machinePoolRef := machine.Spec.MachinePoolRef; machinePoolRef != nil {
 			cells = append(cells, machinePoolRef.Name)
@@ -70,7 +75,7 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 			cells = append(cells, "<none>")
 		}
 		if state := machine.Status.State; state != "" {
-			cells = append(cells, machine.Status.State)
+			cells = append(cells, state)
 		} else {
 			cells = append(cells, "<unknown>")
 		}


### PR DESCRIPTION
Since a `Machine` can boot from a volume, an image standing in for an
in-memory boot is not always required.

cc @gehoern 