### PR TITLE
Fix virtual ip source & make ignition ref secret

### DIFF
--- a/apis/compute/machine_types.go
+++ b/apis/compute/machine_types.go
@@ -41,9 +41,9 @@ type MachineSpec struct {
 	NetworkInterfaces []NetworkInterface
 	// Volumes are volumes attached to this machine.
 	Volumes []Volume
-	// IgnitionRef is a reference to a config map containing the ignition YAML for the machine to boot up.
+	// IgnitionRef is a reference to a secret containing the ignition YAML for the machine to boot up.
 	// If key is empty, DefaultIgnitionKey will be used as fallback.
-	IgnitionRef *commonv1alpha1.ConfigMapKeySelector
+	IgnitionRef *commonv1alpha1.SecretKeySelector
 	// EFIVars are variables to pass to EFI while booting up.
 	EFIVars []EFIVar
 	// Tolerations define tolerations the Machine has. Only MachinePools whose taints

--- a/apis/compute/v1alpha1/machine_types.go
+++ b/apis/compute/v1alpha1/machine_types.go
@@ -43,7 +43,7 @@ type MachineSpec struct {
 	Volumes []Volume `json:"volumes,omitempty"`
 	// IgnitionRef is a reference to a config map containing the ignition YAML for the machine to boot up.
 	// If key is empty, DefaultIgnitionKey will be used as fallback.
-	IgnitionRef *commonv1alpha1.ConfigMapKeySelector `json:"ignitionRef,omitempty"`
+	IgnitionRef *commonv1alpha1.SecretKeySelector `json:"ignitionRef,omitempty"`
 	// EFIVars are variables to pass to EFI while booting up.
 	EFIVars []EFIVar `json:"efiVars,omitempty"`
 	// Tolerations define tolerations the Machine has. Only MachinePools whose taints

--- a/apis/compute/v1alpha1/zz_generated.conversion.go
+++ b/apis/compute/v1alpha1/zz_generated.conversion.go
@@ -773,7 +773,7 @@ func autoConvert_v1alpha1_MachineSpec_To_compute_MachineSpec(in *MachineSpec, ou
 	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.NetworkInterfaces = *(*[]compute.NetworkInterface)(unsafe.Pointer(&in.NetworkInterfaces))
 	out.Volumes = *(*[]compute.Volume)(unsafe.Pointer(&in.Volumes))
-	out.IgnitionRef = (*commonv1alpha1.ConfigMapKeySelector)(unsafe.Pointer(in.IgnitionRef))
+	out.IgnitionRef = (*commonv1alpha1.SecretKeySelector)(unsafe.Pointer(in.IgnitionRef))
 	out.EFIVars = *(*[]compute.EFIVar)(unsafe.Pointer(&in.EFIVars))
 	out.Tolerations = *(*[]commonv1alpha1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	return nil
@@ -792,7 +792,7 @@ func autoConvert_compute_MachineSpec_To_v1alpha1_MachineSpec(in *compute.Machine
 	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.NetworkInterfaces = *(*[]NetworkInterface)(unsafe.Pointer(&in.NetworkInterfaces))
 	out.Volumes = *(*[]Volume)(unsafe.Pointer(&in.Volumes))
-	out.IgnitionRef = (*commonv1alpha1.ConfigMapKeySelector)(unsafe.Pointer(in.IgnitionRef))
+	out.IgnitionRef = (*commonv1alpha1.SecretKeySelector)(unsafe.Pointer(in.IgnitionRef))
 	out.EFIVars = *(*[]EFIVar)(unsafe.Pointer(&in.EFIVars))
 	out.Tolerations = *(*[]commonv1alpha1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	return nil

--- a/apis/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/compute/v1alpha1/zz_generated.deepcopy.go
@@ -495,7 +495,7 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 	}
 	if in.IgnitionRef != nil {
 		in, out := &in.IgnitionRef, &out.IgnitionRef
-		*out = new(commonv1alpha1.ConfigMapKeySelector)
+		*out = new(commonv1alpha1.SecretKeySelector)
 		**out = **in
 	}
 	if in.EFIVars != nil {

--- a/apis/compute/validation/machine_test.go
+++ b/apis/compute/validation/machine_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Machine", func() {
 		Entry("invalid ignition ref name",
 			&compute.Machine{
 				Spec: compute.MachineSpec{
-					IgnitionRef: &commonv1alpha1.ConfigMapKeySelector{
+					IgnitionRef: &commonv1alpha1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "foo*",
 						},

--- a/apis/compute/zz_generated.deepcopy.go
+++ b/apis/compute/zz_generated.deepcopy.go
@@ -495,7 +495,7 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 	}
 	if in.IgnitionRef != nil {
 		in, out := &in.IgnitionRef, &out.IgnitionRef
-		*out = new(v1alpha1.ConfigMapKeySelector)
+		*out = new(v1alpha1.SecretKeySelector)
 		**out = **in
 	}
 	if in.EFIVars != nil {

--- a/apis/networking/v1alpha1/networkinterface_types.go
+++ b/apis/networking/v1alpha1/networkinterface_types.go
@@ -34,7 +34,7 @@ type NetworkInterfaceSpec struct {
 	// this NetworkInterface
 	IPs []IPSource `json:"ips"`
 	// VirtualIP specifies the virtual ip that should be assigned to this NetworkInterface.
-	VirtualIP *VirtualIPSource `json:"virtualIp,omitempty"`
+	VirtualIP *VirtualIPSource `json:"virtualIP,omitempty"`
 }
 
 // IPSource is the definition of how to obtain an IP.

--- a/config/samples/compute_v1alpha1_machine.yaml
+++ b/config/samples/compute_v1alpha1_machine.yaml
@@ -14,4 +14,4 @@ spec:
       volumeRef:
         name: my-volume
   ignitionRef:
-    name: my-ignition-configmap
+    name: my-ignition-secret

--- a/docs/api-reference/compute.md
+++ b/docs/api-reference/compute.md
@@ -165,8 +165,8 @@ Kubernetes core/v1.LocalObjectReference
 <td>
 <code>ignitionRef</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.ConfigMapKeySelector">
-github.com/onmetal/onmetal-api/apis/common/v1alpha1.ConfigMapKeySelector
+<a href="/api-reference/common/#common.onmetal.de/v1alpha1.SecretKeySelector">
+github.com/onmetal/onmetal-api/apis/common/v1alpha1.SecretKeySelector
 </a>
 </em>
 </td>
@@ -1154,8 +1154,8 @@ Kubernetes core/v1.LocalObjectReference
 <td>
 <code>ignitionRef</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.ConfigMapKeySelector">
-github.com/onmetal/onmetal-api/apis/common/v1alpha1.ConfigMapKeySelector
+<a href="/api-reference/common/#common.onmetal.de/v1alpha1.SecretKeySelector">
+github.com/onmetal/onmetal-api/apis/common/v1alpha1.SecretKeySelector
 </a>
 </em>
 </td>

--- a/docs/api-reference/networking.md
+++ b/docs/api-reference/networking.md
@@ -352,7 +352,7 @@ this NetworkInterface</p>
 </tr>
 <tr>
 <td>
-<code>virtualIp</code><br/>
+<code>virtualIP</code><br/>
 <em>
 <a href="#networking.api.onmetal.de/v1alpha1.VirtualIPSource">
 VirtualIPSource
@@ -788,7 +788,7 @@ this NetworkInterface</p>
 </tr>
 <tr>
 <td>
-<code>virtualIp</code><br/>
+<code>virtualIP</code><br/>
 <em>
 <a href="#networking.api.onmetal.de/v1alpha1.VirtualIPSource">
 VirtualIPSource
@@ -966,7 +966,7 @@ this NetworkInterface</p>
 </tr>
 <tr>
 <td>
-<code>virtualIp</code><br/>
+<code>virtualIP</code><br/>
 <em>
 <a href="#networking.api.onmetal.de/v1alpha1.VirtualIPSource">
 VirtualIPSource

--- a/generated/openapi/api_violations.report
+++ b/generated/openapi/api_violations.report
@@ -146,7 +146,6 @@ API rule violation: list_type_missing,k8s.io/apimachinery/pkg/runtime,Unknown,Ra
 API rule violation: names_match,github.com/onmetal/onmetal-api/apis/compute/v1alpha1,MachineSpec,ImagePullSecretRef
 API rule violation: names_match,github.com/onmetal/onmetal-api/apis/compute/v1alpha1,NetworkInterfaceStatus,IPs
 API rule violation: names_match,github.com/onmetal/onmetal-api/apis/networking/v1alpha1,NetworkInterfaceSpec,IPs
-API rule violation: names_match,github.com/onmetal/onmetal-api/apis/networking/v1alpha1,NetworkInterfaceSpec,VirtualIP
 API rule violation: names_match,github.com/onmetal/onmetal-api/apis/networking/v1alpha1,NetworkInterfaceStatus,IPs
 API rule violation: names_match,github.com/onmetal/onmetal-api/apis/networking/v1alpha1,NetworkInterfaceStatus,LastPhaseTransitionTime
 API rule violation: names_match,github.com/onmetal/onmetal-api/apis/networking/v1alpha1,VirtualIPStatus,LastPhaseTransitionTime

--- a/generated/openapi/zz_generated.openapi.go
+++ b/generated/openapi/zz_generated.openapi.go
@@ -1395,7 +1395,7 @@ func schema_onmetal_api_apis_compute_v1alpha1_MachineSpec(ref common.ReferenceCa
 					"ignitionRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "IgnitionRef is a reference to a config map containing the ignition YAML for the machine to boot up. If key is empty, DefaultIgnitionKey will be used as fallback.",
-							Ref:         ref("github.com/onmetal/onmetal-api/apis/common/v1alpha1.ConfigMapKeySelector"),
+							Ref:         ref("github.com/onmetal/onmetal-api/apis/common/v1alpha1.SecretKeySelector"),
 						},
 					},
 					"efiVars": {
@@ -1431,7 +1431,7 @@ func schema_onmetal_api_apis_compute_v1alpha1_MachineSpec(ref common.ReferenceCa
 			},
 		},
 		Dependencies: []string{
-			"github.com/onmetal/onmetal-api/apis/common/v1alpha1.ConfigMapKeySelector", "github.com/onmetal/onmetal-api/apis/common/v1alpha1.Toleration", "github.com/onmetal/onmetal-api/apis/compute/v1alpha1.EFIVar", "github.com/onmetal/onmetal-api/apis/compute/v1alpha1.NetworkInterface", "github.com/onmetal/onmetal-api/apis/compute/v1alpha1.Volume", "k8s.io/api/core/v1.LocalObjectReference"},
+			"github.com/onmetal/onmetal-api/apis/common/v1alpha1.SecretKeySelector", "github.com/onmetal/onmetal-api/apis/common/v1alpha1.Toleration", "github.com/onmetal/onmetal-api/apis/compute/v1alpha1.EFIVar", "github.com/onmetal/onmetal-api/apis/compute/v1alpha1.NetworkInterface", "github.com/onmetal/onmetal-api/apis/compute/v1alpha1.Volume", "k8s.io/api/core/v1.LocalObjectReference"},
 	}
 }
 
@@ -2612,7 +2612,7 @@ func schema_onmetal_api_apis_networking_v1alpha1_NetworkInterfaceSpec(ref common
 							},
 						},
 					},
-					"virtualIp": {
+					"virtualIP": {
 						SchemaProps: spec.SchemaProps{
 							Description: "VirtualIP specifies the virtual ip that should be assigned to this NetworkInterface.",
 							Ref:         ref("github.com/onmetal/onmetal-api/apis/networking/v1alpha1.VirtualIPSource"),


### PR DESCRIPTION
# Proposed Changes

This changes introduces two breaking API changes:
1. Fix `NetworkInterface.Spec.VirtualIP` `json`-tag to be `virtualIP` instead of `virtualIp`
2. Change the type of `Machine.Spec.IgnitionRef` to `SecretKeySelector`. Secrets now have to be used for ignition.