### PR TITLE
Add `NetworkProtection` controller

### DIFF
--- a/config/controller/rbac/role.yaml
+++ b/config/controller/rbac/role.yaml
@@ -220,9 +220,27 @@ rules:
   resources:
   - networks
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
+- apiGroups:
+  - networking.api.onmetal.de
+  resources:
+  - networks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - networking.api.onmetal.de
+  resources:
+  - networks/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - networking.api.onmetal.de
   resources:

--- a/controllers/networking/network_protection_controller.go
+++ b/controllers/networking/network_protection_controller.go
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2022 by the OnMetal authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package networking
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/onmetal/controller-utils/clientutils"
+	networkingv1alpha1 "github.com/onmetal/onmetal-api/apis/networking/v1alpha1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	networkFinalizer     = "networking.api.onmetal.de/network"
+	networkNameFieldPath = ".spec.networkRef.name"
+)
+
+type NetworkProtectionReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=networking.api.onmetal.de,resources=networks,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=networking.api.onmetal.de,resources=networks/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=networking.api.onmetal.de,resources=networks/finalizers,verbs=update
+//+kubebuilder:rbac:groups=networking.api.onmetal.de,resources=networkinterfaces,verbs=get;list;watch
+//+kubebuilder:rbac:groups=networking.api.onmetal.de,resources=aliasprefixes,verbs=get;list;watch
+
+func (r *NetworkProtectionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	network := &networkingv1alpha1.Network{}
+	if err := r.Get(ctx, req.NamespacedName, network); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	return r.reconcileExists(ctx, log, network)
+}
+
+func (r *NetworkProtectionReconciler) reconcileExists(ctx context.Context, log logr.Logger, network *networkingv1alpha1.Network) (ctrl.Result, error) {
+	if !network.DeletionTimestamp.IsZero() {
+		return r.delete(ctx, log, network)
+	}
+	return r.reconcile(ctx, log, network)
+}
+
+func (r *NetworkProtectionReconciler) delete(ctx context.Context, log logr.Logger, network *networkingv1alpha1.Network) (ctrl.Result, error) {
+	log.Info("Deleting Network")
+
+	if networkInUse, err := r.isNetworkInUse(ctx, log, network); err != nil {
+		return ctrl.Result{}, err
+	} else if !networkInUse {
+		log.V(1).Info("Removing finalizer from Network as the Network is not in use")
+		if _, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, network, networkFinalizer); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from network: %w", err)
+		}
+	}
+
+	log.Info("Successfully deleted Network")
+	return ctrl.Result{}, nil
+}
+
+func (r *NetworkProtectionReconciler) reconcile(ctx context.Context, log logr.Logger, network *networkingv1alpha1.Network) (ctrl.Result, error) {
+	log.Info("Reconcile Network")
+
+	var networkInUse bool
+	var err error
+	if networkInUse, err = r.isNetworkInUse(ctx, log, network); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if networkInUse {
+		log.V(1).Info("Patching finalizer from Network as the Network is in use")
+		if _, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, network, networkFinalizer); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to patch finalizer from network: %w", err)
+		}
+	} else {
+		log.V(1).Info("Removing finalizer from Network as the Network is not in use")
+		if _, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, network, networkFinalizer); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from network: %w", err)
+		}
+	}
+
+	log.Info("Successfully reconciled Network")
+	return ctrl.Result{}, nil
+}
+
+func (r *NetworkProtectionReconciler) isNetworkInUse(ctx context.Context, log logr.Logger, network *networkingv1alpha1.Network) (bool, error) {
+	log.V(1).Info("Checking if the Network is in use")
+
+	// NetworkInterfaces
+	networkInterfaces := &networkingv1alpha1.NetworkInterfaceList{}
+	if err := r.List(ctx, networkInterfaces, &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(networkNameFieldPath, network.Name),
+	}); err != nil {
+		return false, fmt.Errorf("failed to list NetworkInterfaces: %w", err)
+	}
+	for _, networkInterface := range networkInterfaces.Items {
+		// Skip NetworkInterfaces which are deletion candidates
+		if networkInterface.DeletionTimestamp.IsZero() {
+			log.V(1).Info("Network is in use by NetworkInterface", "NetworkInterface", client.ObjectKeyFromObject(&networkInterface))
+			return true, nil
+		}
+	}
+
+	// AliasPrefixes
+	aliasPrefixes := &networkingv1alpha1.AliasPrefixList{}
+	if err := r.List(ctx, aliasPrefixes, &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(networkNameFieldPath, network.Name),
+	}); err != nil {
+		return false, fmt.Errorf("failed to list NetworkInterfaces: %w", err)
+	}
+	for _, aliasPrefix := range aliasPrefixes.Items {
+		// Skip AliasPrefixes which are deletion candidates
+		if aliasPrefix.DeletionTimestamp.IsZero() {
+			log.V(1).Info("Network is in use by AliasPrefix", "AliasPrefix", client.ObjectKeyFromObject(&aliasPrefix))
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (r *NetworkProtectionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&networkingv1alpha1.Network{}).
+		Watches(
+			&source.Kind{Type: &networkingv1alpha1.NetworkInterface{}},
+			r.enqueueNetworkUsedByNetworkInterface(),
+		).
+		Watches(
+			&source.Kind{Type: &networkingv1alpha1.AliasPrefix{}},
+			r.enqueueNetworkUsedByAliasPrefix(),
+		).
+		Complete(r)
+}
+
+func (r *NetworkProtectionReconciler) enqueueNetworkUsedByNetworkInterface() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []ctrl.Request {
+		nic := obj.(*networkingv1alpha1.NetworkInterface)
+
+		var res []ctrl.Request
+		networkKey := types.NamespacedName{
+			Namespace: nic.Namespace,
+			Name:      nic.Spec.NetworkRef.Name,
+		}
+		res = append(res, ctrl.Request{NamespacedName: networkKey})
+
+		return res
+	})
+}
+
+func (r *NetworkProtectionReconciler) enqueueNetworkUsedByAliasPrefix() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []ctrl.Request {
+		aliasPrefix := obj.(*networkingv1alpha1.AliasPrefix)
+
+		var res []ctrl.Request
+		networkKey := types.NamespacedName{
+			Namespace: aliasPrefix.Namespace,
+			Name:      aliasPrefix.Spec.NetworkRef.Name,
+		}
+		res = append(res, ctrl.Request{NamespacedName: networkKey})
+
+		return res
+	})
+}

--- a/controllers/networking/network_protection_controller.go
+++ b/controllers/networking/network_protection_controller.go
@@ -83,18 +83,9 @@ func (r *NetworkProtectionReconciler) delete(ctx context.Context, log logr.Logge
 func (r *NetworkProtectionReconciler) reconcile(ctx context.Context, log logr.Logger, network *networkingv1alpha1.Network) (ctrl.Result, error) {
 	log.Info("Reconcile Network")
 
-	log.V(1).Info("Patching finalizer from Network as the Network is in use")
+	log.V(1).Info("Ensuring finalizer on Network")
 	if _, err := clientutils.PatchEnsureFinalizer(ctx, r.Client, network, networkFinalizer); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to patch finalizer from network: %w", err)
-	}
-
-	if ok, err := r.isNetworkInUse(ctx, log, network); err != nil || ok {
-		return ctrl.Result{}, err
-	} else {
-		log.V(1).Info("Removing finalizer from Network as the Network is not in use")
-		if _, err := clientutils.PatchEnsureNoFinalizer(ctx, r.Client, network, networkFinalizer); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from network: %w", err)
-		}
 	}
 
 	log.Info("Successfully reconciled Network")

--- a/controllers/networking/network_protection_controller_test.go
+++ b/controllers/networking/network_protection_controller_test.go
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2022 by the OnMetal authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package networking
+
+import (
+	"github.com/onmetal/onmetal-api/apis/common/v1alpha1"
+	networkingv1alpha1 "github.com/onmetal/onmetal-api/apis/networking/v1alpha1"
+	"github.com/onmetal/onmetal-api/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("NetworkProtectionReconciler", func() {
+	ctx := testutils.SetupContext()
+	ns := SetupTest(ctx)
+
+	var (
+		network *networkingv1alpha1.Network
+	)
+
+	BeforeEach(func() {
+		By("creating a network")
+		network = &networkingv1alpha1.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "my-network-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, network)).To(Succeed())
+	})
+
+	It("should add and remove a finalizer for a network in use/not used by a network interface", func() {
+		By("creating a network interface referencing this network")
+		networkInterface := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "my-networkinterface-",
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{
+					Name: network.Name,
+				},
+				IPFamilies: []corev1.IPFamily{
+					corev1.IPv4Protocol,
+				},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: v1alpha1.MustParseNewIP("10.0.0.1"),
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, networkInterface)).To(Succeed())
+
+		By("ensuring that the network finalizer has been set")
+		networkKey := types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      network.Name,
+		}
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
+		}).Should(Succeed())
+
+		By("deleting the network interface")
+		Expect(k8sClient.Delete(ctx, networkInterface)).To(Succeed())
+
+		By("ensuring that the finalizer has been removed from the network")
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.GetFinalizers()).To(BeEmpty())
+		}).Should(Succeed())
+
+		By("deleting the network")
+		Expect(k8sClient.Delete(ctx, network)).To(Succeed())
+
+		By("ensuring that the network has been deleted")
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).To(BeNil())
+		}).Should(Succeed())
+	})
+
+	It("should remove a finalizer for a network in deletion state once the reference network interface is deleted", func() {
+		By("creating a network interface referencing this network")
+		networkInterface := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "my-networkinterface-",
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{
+					Name: network.Name,
+				},
+				IPFamilies: []corev1.IPFamily{
+					corev1.IPv4Protocol,
+				},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: v1alpha1.MustParseNewIP("10.0.0.1"),
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, networkInterface)).To(Succeed())
+
+		By("ensuring that the network finalizer has been set")
+		networkKey := types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      network.Name,
+		}
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
+		}).Should(Succeed())
+
+		By("deleting the network")
+		Expect(k8sClient.Delete(ctx, network)).To(Succeed())
+
+		By("ensuring that the network has a deletion timestamp set and the finalizer still present")
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.DeletionTimestamp.IsZero()).To(BeFalse())
+			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
+		}).Should(Succeed())
+
+		By("deleting the network interface")
+		Expect(k8sClient.Delete(ctx, networkInterface)).To(Succeed())
+
+		By("ensuring that the network has been deleted")
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).To(BeNil())
+		}).Should(Succeed())
+	})
+
+	It("should keep a finalizer if one of two network interfaces is removed", func() {
+		By("creating the first network interface referencing this network")
+		networkInterface := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "my-networkinterface-",
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{
+					Name: network.Name,
+				},
+				IPFamilies: []corev1.IPFamily{
+					corev1.IPv4Protocol,
+				},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: v1alpha1.MustParseNewIP("10.0.0.1"),
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, networkInterface)).To(Succeed())
+
+		By("creating a second network interface referencing this network")
+		networkInterface2 := &networkingv1alpha1.NetworkInterface{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "my-networkinterface-",
+			},
+			Spec: networkingv1alpha1.NetworkInterfaceSpec{
+				NetworkRef: corev1.LocalObjectReference{
+					Name: network.Name,
+				},
+				IPFamilies: []corev1.IPFamily{
+					corev1.IPv4Protocol,
+				},
+				IPs: []networkingv1alpha1.IPSource{{
+					Value: v1alpha1.MustParseNewIP("10.0.0.2"),
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, networkInterface2)).To(Succeed())
+
+		By("ensuring that the network finalizer has been set")
+		networkKey := types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      network.Name,
+		}
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
+		}).Should(Succeed())
+
+		By("deleting the first network interface")
+		Expect(k8sClient.Delete(ctx, networkInterface)).To(Succeed())
+
+		By("ensuring that the finalizer is still present")
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
+		}).Should(Succeed())
+
+		By("deleting the network")
+		Expect(k8sClient.Delete(ctx, network)).To(Succeed())
+
+		By("ensuring that the network has a deletion timestamp set and finalizer still present")
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.DeletionTimestamp.IsZero()).To(BeFalse())
+			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
+		}).Should(Succeed())
+	})
+
+	It("should add/remove a finalizer for a network in use/not used by an alias prefix", func() {
+		By("creating an alias prefix referencing this network")
+		aliasPrefix := &networkingv1alpha1.AliasPrefix{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "my-aliasprefix-",
+			},
+			Spec: networkingv1alpha1.AliasPrefixSpec{
+				NetworkRef: corev1.LocalObjectReference{
+					Name: network.Name,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, aliasPrefix)).To(Succeed())
+
+		By("ensuring that the network finalizer has been set")
+		networkKey := types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      network.Name,
+		}
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
+		}).Should(Succeed())
+
+		By("deleting the alias prefix")
+		Expect(k8sClient.Delete(ctx, aliasPrefix)).To(Succeed())
+
+		By("ensuring that the finalizer has been removed from the network")
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.GetFinalizers()).To(BeEmpty())
+		}).Should(Succeed())
+
+		By("deleting the network")
+		Expect(k8sClient.Delete(ctx, network)).To(Succeed())
+
+		By("ensuring that the network has been deleted")
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).To(BeNil())
+		}).Should(Succeed())
+	})
+
+	It("should keep a finalizer if one of two alias prefix is removed", func() {
+		By("creating the first alias prefix referencing this network")
+		aliasPrefix := &networkingv1alpha1.AliasPrefix{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "my-aliasprefix-",
+			},
+			Spec: networkingv1alpha1.AliasPrefixSpec{
+				NetworkRef: corev1.LocalObjectReference{
+					Name: network.Name,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, aliasPrefix)).To(Succeed())
+
+		By("creating a second alias prefix referencing this network")
+		aliasPrefix2 := &networkingv1alpha1.AliasPrefix{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "my-aliasprefix-",
+			},
+			Spec: networkingv1alpha1.AliasPrefixSpec{
+				NetworkRef: corev1.LocalObjectReference{
+					Name: network.Name,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, aliasPrefix2)).To(Succeed())
+
+		By("ensuring that the network finalizer has been set")
+		networkKey := types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      network.Name,
+		}
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
+		}).Should(Succeed())
+
+		By("deleting the first alias prefix")
+		Expect(k8sClient.Delete(ctx, aliasPrefix)).To(Succeed())
+
+		By("ensuring that the finalizer has been removed from the network")
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
+		}).Should(Succeed())
+
+		By("deleting the network")
+		Expect(k8sClient.Delete(ctx, network)).To(Succeed())
+
+		By("ensuring that the network has a deletion timestamp set and finalizer still present")
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(network.DeletionTimestamp.IsZero()).To(BeFalse())
+			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
+		}).Should(Succeed())
+	})
+
+	It("should allow deletion of an unused network", func() {
+		By("deleting the network")
+		Expect(k8sClient.Delete(ctx, network)).To(Succeed())
+
+		By("ensuring that the network is not found")
+		networkKey := types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      network.Name,
+		}
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, networkKey, network)
+			Expect(client.IgnoreNotFound(err)).To(BeNil())
+		}).Should(Succeed())
+	})
+})

--- a/controllers/networking/network_protection_controller_test.go
+++ b/controllers/networking/network_protection_controller_test.go
@@ -84,15 +84,6 @@ var _ = Describe("NetworkProtectionReconciler", func() {
 		By("deleting the network interface")
 		Expect(k8sClient.Delete(ctx, networkInterface)).To(Succeed())
 
-		By("ensuring that the finalizer has been removed from the network")
-		Eventually(func(g Gomega) {
-			err := k8sClient.Get(ctx, networkKey, network)
-			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
-			g.Expect(err).NotTo(HaveOccurred())
-
-			g.Expect(network.GetFinalizers()).To(BeEmpty())
-		}).Should(Succeed())
-
 		By("deleting the network")
 		Expect(k8sClient.Delete(ctx, network)).To(Succeed())
 
@@ -217,15 +208,6 @@ var _ = Describe("NetworkProtectionReconciler", func() {
 		By("deleting the first network interface")
 		Expect(k8sClient.Delete(ctx, networkInterface)).To(Succeed())
 
-		By("ensuring that the finalizer is still present")
-		Eventually(func(g Gomega) {
-			err := k8sClient.Get(ctx, networkKey, network)
-			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
-			g.Expect(err).NotTo(HaveOccurred())
-
-			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
-		}).Should(Succeed())
-
 		By("deleting the network")
 		Expect(k8sClient.Delete(ctx, network)).To(Succeed())
 
@@ -270,15 +252,6 @@ var _ = Describe("NetworkProtectionReconciler", func() {
 
 		By("deleting the alias prefix")
 		Expect(k8sClient.Delete(ctx, aliasPrefix)).To(Succeed())
-
-		By("ensuring that the finalizer has been removed from the network")
-		Eventually(func(g Gomega) {
-			err := k8sClient.Get(ctx, networkKey, network)
-			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
-			g.Expect(err).NotTo(HaveOccurred())
-
-			g.Expect(network.GetFinalizers()).To(BeEmpty())
-		}).Should(Succeed())
 
 		By("deleting the network")
 		Expect(k8sClient.Delete(ctx, network)).To(Succeed())
@@ -334,15 +307,6 @@ var _ = Describe("NetworkProtectionReconciler", func() {
 
 		By("deleting the first alias prefix")
 		Expect(k8sClient.Delete(ctx, aliasPrefix)).To(Succeed())
-
-		By("ensuring that the finalizer has been removed from the network")
-		Eventually(func(g Gomega) {
-			err := k8sClient.Get(ctx, networkKey, network)
-			Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
-			g.Expect(err).NotTo(HaveOccurred())
-
-			g.Expect(network.GetFinalizers()).To(ContainElement(networkFinalizer))
-		}).Should(Succeed())
 
 		By("deleting the network")
 		Expect(k8sClient.Delete(ctx, network)).To(Succeed())

--- a/controllers/networking/suite_test.go
+++ b/controllers/networking/suite_test.go
@@ -167,6 +167,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&NetworkProtectionReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+	}).SetupWithManager(k8sManager)
+	Expect(err).NotTo(HaveOccurred())
+
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ const (
 	prefixController          = "prefix"
 	prefixAllocationScheduler = "prefixallocationscheduler"
 
+	networkProtectionController    = "networkprotection"
 	networkInterfaceController     = "networkinterface"
 	networkInterfaceBindController = "networkinterfacebind"
 	virtualIPController            = "virtualip"
@@ -109,7 +110,7 @@ func main() {
 		volumePoolController, volumeClassController, volumeController, volumeScheduler,
 
 		// Networking controllers
-		networkInterfaceController, networkInterfaceBindController, virtualIPController, aliasPrefixController,
+		networkProtectionController, networkInterfaceController, networkInterfaceBindController, virtualIPController, aliasPrefixController,
 
 		// IPAM controllers
 		prefixController, prefixAllocationScheduler,
@@ -263,6 +264,16 @@ func main() {
 			EventRecorder: mgr.GetEventRecorderFor("prefix-allocation-scheduler"),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "PrefixAllocationScheduler")
+			os.Exit(1)
+		}
+	}
+
+	if controllers.Enabled(networkProtectionController) {
+		if err = (&networking.NetworkProtectionReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "NetworkProtection")
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
# Proposed Changes

The `NetworkProtection` controller ensures that a finalizer is present on the `Network` resource as long as it is being referenced/used by resources like `NetworkInterface`s or `AliasPrefix`es.

Fixes #444 