### PR TITLE
Common `ResourceName`s for `VolumeClass`

### DIFF
--- a/apis/storage/v1alpha1/volumeclass_types.go
+++ b/apis/storage/v1alpha1/volumeclass_types.go
@@ -21,6 +21,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// ResourceTPS defines max throughput per second. (e.g. 1Gi)
+	ResourceTPS corev1.ResourceName = "tps"
+	// ResourceIOPS defines max IOPS in input/output operations per second.
+	ResourceIOPS corev1.ResourceName = "iops"
+)
+
 var (
 	// VolumeClassFinalizer is the finalizer for VolumeClass.
 	VolumeClassFinalizer = SchemeGroupVersion.Group + "/volumeclass"

--- a/apis/storage/volumeclass_types.go
+++ b/apis/storage/volumeclass_types.go
@@ -21,6 +21,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// Max throughput in bytes per seconds.
+	ResourceBPS corev1.ResourceName = "bps"
+	// Max IOPS in input/output operations per second.
+	ResourceIOPS corev1.ResourceName = "iops"
+	// Dynamic resource limits flag: limits  per GB of volume.
+	ResourceDynamic corev1.ResourceName = "dynamic"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient
 // +genclient:nonNamespaced

--- a/apis/storage/volumeclass_types.go
+++ b/apis/storage/volumeclass_types.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	// Max throughput in bytes per seconds.
-	ResourceBPS corev1.ResourceName = "bps"
+	// Max throughput per second. (e.g. 1Gi)
+	ResourceTPS corev1.ResourceName = "tps"
 	// Max IOPS in input/output operations per second.
 	ResourceIOPS corev1.ResourceName = "iops"
 	// Dynamic resource limits flag: limits  per GB of volume.

--- a/apis/storage/volumeclass_types.go
+++ b/apis/storage/volumeclass_types.go
@@ -22,12 +22,10 @@ import (
 )
 
 const (
-	// Max throughput per second. (e.g. 1Gi)
+	// ResourceTPS defines max throughput per second. (e.g. 1Gi)
 	ResourceTPS corev1.ResourceName = "tps"
-	// Max IOPS in input/output operations per second.
+	// ResourceIOPS defines max IOPS in input/output operations per second.
 	ResourceIOPS corev1.ResourceName = "iops"
-	// Dynamic resource limits flag: limits  per GB of volume.
-	ResourceDynamic corev1.ResourceName = "dynamic"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
# Proposed Changes

- Define `ResourceName`s for `VolumeClass` that storage providers can use constants to check for default resources
