### PR TITLE
Add OpenAPI v2 and v3 extraction Makefile directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,10 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test-only: envtest ## Run *only* the tests - no generation, linting etc.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+.PHONEY: openapi-extractor
+extract-openapi: openapi-extractor
+	$(OPENAPI_EXTRACTOR) --apiserver-package="github.com/onmetal/onmetal-api/cmd/apiserver" --apiserver-build-opts=mod --apiservices="./config/apiserver/apiservice/bases" --output="./gen"
+
 ##@ Build
 
 .PHONY: build
@@ -221,6 +225,7 @@ $(LOCALBIN):
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+OPENAPI_EXTRACTOR ?= $(LOCALBIN)/openapi-extractor
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
@@ -242,3 +247,7 @@ envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
+.PHONY: openapi-extractor
+openapi-extractor: $(OPENAPI_EXTRACTOR) ## Download openapi-extractor locally if necessary.
+$(OPENAPI_EXTRACTOR): $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install github.com/onmetal/openapi-extractor/cmd/openapi-extractor@latest

--- a/gen/v3/apis__compute.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__compute.api.onmetal.de__v1alpha1_openapi.json
@@ -1,0 +1,20902 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"title": "onmetal-api",
+		"version": "0.1"
+	},
+	"paths": {
+		"/apis/": {
+			"get": {
+				"tags": [
+					"apis"
+				],
+				"description": "get available API versions",
+				"operationId": "getAPIVersions",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getComputeApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getComputeApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machineclasses": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind MachineClass",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a MachineClass",
+				"operationId": "createComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of MachineClass",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionMachineClass",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machineclasses/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified MachineClass",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachineClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified MachineClass",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a MachineClass",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified MachineClass",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind MachinePool",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a MachinePool",
+				"operationId": "createComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of MachinePool",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionMachinePool",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified MachinePool",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachinePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified MachinePool",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a MachinePool",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified MachinePool",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools/{name}/status": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified MachinePool",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified MachinePool",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified MachinePool",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Machine",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachineForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Machine",
+				"operationId": "listComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Machine",
+				"operationId": "createComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Machine",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionNamespacedMachine",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Machine",
+				"operationId": "readComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Machine",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Machine",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Machine",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}/exec": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "connect GET requests to exec of Machine",
+				"operationId": "connectComputeApiOnmetalDeV1alpha1GetNamespacedMachineExec",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "connect",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineExecOptions",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "connect POST requests to exec of Machine",
+				"operationId": "connectComputeApiOnmetalDeV1alpha1PostNamespacedMachineExec",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "connect",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineExecOptions",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "insecureSkipTLSVerifyBackend",
+					"in": "query",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineExecOptions",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}/status": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Machine",
+				"operationId": "readComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Machine",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Machine",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machineclasses": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of MachineClass. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineClassList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machineclasses/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind MachineClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machinepools": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of MachinePool. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachinePoolList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machinepools/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind MachinePool. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachinePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Machine. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Machine. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1NamespacedMachineList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/machines/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Machine. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getIpamApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getIpamApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind PrefixAllocation",
+				"operationId": "listIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a PrefixAllocation",
+				"operationId": "createIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of PrefixAllocation",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1CollectionNamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified PrefixAllocation",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified PrefixAllocation",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a PrefixAllocation",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified PrefixAllocation",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations/{name}/status": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified PrefixAllocation",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified PrefixAllocation",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified PrefixAllocation",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Prefix",
+				"operationId": "listIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Prefix",
+				"operationId": "createIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Prefix",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1CollectionNamespacedPrefix",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Prefix",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Prefix",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Prefix",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Prefix",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes/{name}/status": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Prefix",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Prefix",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Prefix",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind PrefixAllocation",
+				"operationId": "listIpamApiOnmetalDeV1alpha1PrefixAllocationForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Prefix",
+				"operationId": "listIpamApiOnmetalDeV1alpha1PrefixForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixallocations/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Prefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixes/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Prefix. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1PrefixAllocationListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Prefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1PrefixListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getNetworkingApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getNetworkingApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefix",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1AliasPrefixForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefixRouting",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1AliasPrefixRoutingForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefix",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create an AliasPrefix",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of AliasPrefix",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified AliasPrefix",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified AliasPrefix",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete an AliasPrefix",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified AliasPrefix",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified AliasPrefix",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified AliasPrefix",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified AliasPrefix",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefixRouting",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create an AliasPrefixRouting",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of AliasPrefixRouting",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixroutings/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified AliasPrefixRouting",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified AliasPrefixRouting",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete an AliasPrefixRouting",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified AliasPrefixRouting",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefixRouting",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind NetworkInterface",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a NetworkInterface",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of NetworkInterface",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified NetworkInterface",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified NetworkInterface",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a NetworkInterface",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified NetworkInterface",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified NetworkInterface",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified NetworkInterface",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified NetworkInterface",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Network",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Network",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Network",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedNetwork",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networks/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Network",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Network",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Network",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Network",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Network",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VirtualIP",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VirtualIP",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VirtualIP",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VirtualIP",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VirtualIP",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VirtualIP",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VirtualIP",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified VirtualIP",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified VirtualIP",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified VirtualIP",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind NetworkInterface",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NetworkInterfaceForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Network",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NetworkForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VirtualIP",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1VirtualIPForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1AliasPrefixListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1AliasPrefixRoutingListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixes/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRoutingList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixroutings/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefixRouting",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networkinterfaces/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Network. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networks/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Network. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Network",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VirtualIP. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/virtualips/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VirtualIP. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NetworkInterfaceListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Network. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NetworkListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VirtualIP. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1VirtualIPListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getStorageApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getStorageApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Volume",
+				"operationId": "listStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Volume",
+				"operationId": "createStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Volume",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionNamespacedVolume",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Volume",
+				"operationId": "readStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Volume",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Volume",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Volume",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes/{name}/status": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Volume",
+				"operationId": "readStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Volume",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Volume",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumeclasses": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VolumeClass",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VolumeClass",
+				"operationId": "createStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VolumeClass",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionVolumeClass",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumeclasses/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VolumeClass",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumeClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VolumeClass",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VolumeClass",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VolumeClass",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumeClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VolumePool",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VolumePool",
+				"operationId": "createStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VolumePool",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionVolumePool",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VolumePool",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VolumePool",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VolumePool",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VolumePool",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools/{name}/status": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified VolumePool",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified VolumePool",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified VolumePool",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Volume",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumeForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Volume. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1NamespacedVolumeList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/volumes/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Volume. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumeclasses": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VolumeClass. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeClassList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumeclasses/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VolumeClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumeClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumepools": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VolumePool. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumePoolList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumepools/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VolumePool. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Volume. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/version/": {
+			"get": {
+				"tags": [
+					"version"
+				],
+				"description": "get the code version",
+				"operationId": "getCodeVersion",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.version.Info"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP": {
+				"description": "IP is an IP address.",
+				"type": "string",
+				"format": "ip"
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix": {
+				"description": "IPPrefix represents a network prefix.",
+				"type": "string",
+				"format": "ip-prefix"
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference": {
+				"description": "LocalUIDReference is a reference to another entity including its UID",
+				"type": "object",
+				"required": [
+					"name",
+					"uid"
+				],
+				"properties": {
+					"name": {
+						"description": "Name is the name of the referenced entity.",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID is the UID of the referenced entity.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.SecretKeySelector": {
+				"description": "SecretKeySelector is a reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+				"type": "object",
+				"properties": {
+					"key": {
+						"description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+						"type": "string"
+					},
+					"name": {
+						"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint": {
+				"description": "The resource pool this Taint is attached to has the \"effect\" on any resource that does not tolerate the Taint.",
+				"type": "object",
+				"required": [
+					"key",
+					"effect"
+				],
+				"properties": {
+					"effect": {
+						"description": "The effect of the taint on resources that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+						"type": "string"
+					},
+					"key": {
+						"description": "The taint key to be applied to a resource pool.",
+						"type": "string"
+					},
+					"value": {
+						"description": "The taint value corresponding to the taint key.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration": {
+				"description": "The resource this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+				"type": "object",
+				"properties": {
+					"effect": {
+						"description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule.",
+						"type": "string"
+					},
+					"key": {
+						"description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+						"type": "string"
+					},
+					"operator": {
+						"description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a resource can tolerate all taints of a particular category.",
+						"type": "string"
+					},
+					"value": {
+						"description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.DaemonEndpoint": {
+				"description": "DaemonEndpoint contains information about a single Daemon endpoint.",
+				"type": "object",
+				"required": [
+					"port"
+				],
+				"properties": {
+					"port": {
+						"description": "Port number of the given endpoint.",
+						"type": "integer",
+						"format": "int32"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EFIVar": {
+				"description": "EFIVar is a variable to pass to EFI while booting up.",
+				"type": "object",
+				"required": [
+					"name",
+					"uuid",
+					"value"
+				],
+				"properties": {
+					"name": {
+						"description": "Name is the name of the EFIVar.",
+						"type": "string"
+					},
+					"uuid": {
+						"description": "UUID is the uuid of the EFIVar.",
+						"type": "string"
+					},
+					"value": {
+						"description": "Value is the value of the EFIVar.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EmptyDiskVolumeSource": {
+				"description": "EmptyDiskVolumeSource is a volume that's offered by the machine pool provider. Usually ephemeral (i.e. deleted when the surrounding entity is deleted), with varying performance characteristics. Potentially not recoverable.",
+				"type": "object",
+				"properties": {
+					"sizeLimit": {
+						"description": "SizeLimit is the total amount of local storage required for this EmptyDisk volume. The default is nil which means that the limit is undefined.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralNetworkInterfaceSource": {
+				"description": "EphemeralNetworkInterfaceSource is a definition for an ephemeral (i.e. coupled to the lifetime of the surrounding object) networking.NetworkInterface.",
+				"type": "object",
+				"properties": {
+					"networkInterfaceTemplate": {
+						"description": "NetworkInterfaceTemplate is the template definition of the networking.NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralVolumeSource": {
+				"description": "EphemeralVolumeSource is a definition for an ephemeral (i.e. coupled to the lifetime of the surrounding object) storage.Volume.",
+				"type": "object",
+				"properties": {
+					"volumeTemplate": {
+						"description": "VolumeTemplate is the template definition of the storage.Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine": {
+				"description": "Machine is the Schema for the machines API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "Machine",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass": {
+				"description": "MachineClass is the Schema for the machineclasses API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"capabilities": {
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineClass",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList": {
+				"description": "MachineClassList contains a list of MachineClass",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineClassList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineCondition": {
+				"description": "MachineCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList": {
+				"description": "MachineList contains a list of Machine",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool": {
+				"description": "MachinePool is the Schema for the machinepools API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachinePool",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolAddress": {
+				"type": "object",
+				"required": [
+					"type",
+					"address"
+				],
+				"properties": {
+					"address": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolCondition": {
+				"description": "MachinePoolCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status",
+					"reason",
+					"message"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolDaemonEndpoints": {
+				"description": "MachinePoolDaemonEndpoints lists ports opened by daemons running on the MachinePool.",
+				"type": "object",
+				"properties": {
+					"machinepoolletEndpoint": {
+						"description": "Endpoint on which machinepoollet is listening.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.DaemonEndpoint"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList": {
+				"description": "MachinePoolList contains a list of MachinePool",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachinePoolList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolSpec": {
+				"description": "MachinePoolSpec defines the desired state of MachinePool",
+				"type": "object",
+				"required": [
+					"providerID"
+				],
+				"properties": {
+					"providerID": {
+						"description": "ProviderID identifies the MachinePool on provider side.",
+						"type": "string"
+					},
+					"taints": {
+						"description": "Taints of the MachinePool. Only Machines who tolerate all the taints will land in the MachinePool.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolStatus": {
+				"description": "MachinePoolStatus defines the observed state of MachinePool",
+				"type": "object",
+				"properties": {
+					"addresses": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolAddress"
+						}
+					},
+					"availableMachineClasses": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+						}
+					},
+					"conditions": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolCondition"
+						}
+					},
+					"daemonEndpoints": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolDaemonEndpoints"
+					},
+					"state": {
+						"description": "Possible enum values:\n - `\"Error\"` marks a MachinePool in an error state.\n - `\"Offline\"` marks a MachinePool as offline.\n - `\"Pending\"` marks a MachinePool as pending readiness.\n - `\"Ready\"` marks a MachinePool as ready for accepting a Machine.",
+						"type": "string",
+						"enum": [
+							"Error",
+							"Offline",
+							"Pending",
+							"Ready"
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineSpec": {
+				"description": "MachineSpec defines the desired state of Machine",
+				"type": "object",
+				"required": [
+					"machineClassRef",
+					"image"
+				],
+				"properties": {
+					"efiVars": {
+						"description": "EFIVars are variables to pass to EFI while booting up.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EFIVar"
+						}
+					},
+					"ignitionRef": {
+						"description": "IgnitionRef is a reference to a config map containing the ignition YAML for the machine to boot up. If key is empty, DefaultIgnitionKey will be used as fallback.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.SecretKeySelector"
+							}
+						]
+					},
+					"image": {
+						"description": "Image is the URL providing the operating system image of the machine.",
+						"type": "string"
+					},
+					"imagePullSecret": {
+						"description": "ImagePullSecretRef is an optional secret for pulling the image of a machine.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machineClassRef": {
+						"description": "MachineClassRef is a reference to the machine class/flavor of the machine.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machinePoolRef": {
+						"description": "MachinePoolRef defines machine pool to run the machine in. If empty, a scheduler will figure out an appropriate pool to run the machine in.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machinePoolSelector": {
+						"description": "MachinePoolSelector selects a suitable MachinePoolRef by the given labels.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"networkInterfaces": {
+						"description": "NetworkInterfaces define a list of network interfaces present on the machine",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterface"
+						}
+					},
+					"tolerations": {
+						"description": "Tolerations define tolerations the Machine has. Only MachinePools whose taints covered by Tolerations will be considered to run the Machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration"
+						}
+					},
+					"volumes": {
+						"description": "Volumes are volumes attached to this machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Volume"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineStatus": {
+				"description": "MachineStatus defines the observed state of Machine",
+				"type": "object",
+				"properties": {
+					"conditions": {
+						"description": "Conditions are the conditions of the machines.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineCondition"
+						}
+					},
+					"networkInterfaces": {
+						"description": "NetworkInterfaces is the list of network interface states for the machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterfaceStatus"
+						}
+					},
+					"state": {
+						"description": "State is the state of the machine.\n\nPossible enum values:\n - `\"Error\"` means the machine is in an error state.\n - `\"Pending\"` means the Machine has been accepted by the system, but not yet completely started. This includes time before being bound to a MachinePool, as well as time spent setting up the Machine on that MachinePool.\n - `\"Running\"` means the machine is running on a MachinePool.\n - `\"Shutdown\"` means the machine is shut down.",
+						"type": "string",
+						"enum": [
+							"Error",
+							"Pending",
+							"Running",
+							"Shutdown"
+						]
+					},
+					"volumes": {
+						"description": "Volumes is the list of volume states for the machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.VolumeStatus"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterface": {
+				"description": "NetworkInterface is the definition of a single interface",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) NetworkInterface to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralNetworkInterfaceSource"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the network interface.",
+						"type": "string"
+					},
+					"networkInterfaceRef": {
+						"description": "NetworkInterfaceRef instructs to use the NetworkInterface at the target reference.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterfaceStatus": {
+				"description": "NetworkInterfaceStatus reports the status of an NetworkInterfaceSource.",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"ips": {
+						"description": "IPs are the ips allocated for the network interface.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+						}
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the NetworkInterface to whom the status belongs to.",
+						"type": "string"
+					},
+					"phase": {
+						"description": "Phase is the NetworkInterface binding phase of the NetworkInterface.",
+						"type": "string"
+					},
+					"virtualIP": {
+						"description": "VirtualIP is the virtual ip allocated for the network interface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Volume": {
+				"description": "Volume defines a volume attachment of a machine",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"device": {
+						"description": "Device is the device name where the volume should be attached. If empty, an unused device name will be determined if possible.",
+						"type": "string"
+					},
+					"emptyDisk": {
+						"description": "EmptyDisk instructs to use a Volume offered by the machine pool provider.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EmptyDiskVolumeSource"
+							}
+						]
+					},
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) Volume to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralVolumeSource"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the Volume",
+						"type": "string"
+					},
+					"volumeRef": {
+						"description": "VolumeRef instructs to use the specified Volume as source for the attachment.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.VolumeStatus": {
+				"description": "VolumeStatus is the status of a Volume.",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"deviceID": {
+						"description": "DeviceID is the disk device ID on the host.",
+						"type": "string"
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of a volume attachment.",
+						"type": "string"
+					},
+					"phase": {
+						"description": "Phase represents the binding phase of a Volume.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix": {
+				"description": "Prefix is the Schema for the prefixes API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "Prefix",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation": {
+				"description": "PrefixAllocation is the Schema for the prefixallocations API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixAllocation",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList": {
+				"description": "PrefixAllocationList contains a list of PrefixAllocation",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixAllocationList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationSpec": {
+				"description": "PrefixAllocationSpec defines the desired state of PrefixAllocation",
+				"type": "object",
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the IPFamily of the prefix. If unset but Prefix is set, this can be inferred.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the prefix to allocate for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					},
+					"prefixLength": {
+						"description": "PrefixLength is the length of prefix to allocate for this Prefix.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"prefixRef": {
+						"description": "PrefixRef references the prefix to allocate from.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"prefixSelector": {
+						"description": "PrefixSelector selects the prefix to allocate from.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationStatus": {
+				"description": "PrefixAllocationStatus is the status of a PrefixAllocation.",
+				"type": "object",
+				"properties": {
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase changed values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the phase of the PrefixAllocation.",
+						"type": "string"
+					},
+					"prefix": {
+						"description": "Prefix is the allocated prefix, if any",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList": {
+				"description": "PrefixList contains a list of Prefix",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec": {
+				"description": "PrefixSpec defines the desired state of Prefix",
+				"type": "object",
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the IPFamily of the prefix. If unset but Prefix is set, this can be inferred.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"parentRef": {
+						"description": "ParentRef references the parent to allocate the Prefix from. If ParentRef and ParentSelector is empty, the Prefix is considered a root prefix and thus allocated by itself.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"parentSelector": {
+						"description": "ParentSelector is the LabelSelector to use for determining the parent for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the prefix to allocate for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					},
+					"prefixLength": {
+						"description": "PrefixLength is the length of prefix to allocate for this Prefix.",
+						"type": "integer",
+						"format": "int32"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixStatus": {
+				"description": "PrefixStatus defines the observed state of Prefix",
+				"type": "object",
+				"properties": {
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase changed values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the PrefixPhase of the Prefix.",
+						"type": "string"
+					},
+					"used": {
+						"description": "Used is a list of used prefixes.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixTemplateSpec": {
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix": {
+				"description": "AliasPrefix is the Schema for the AliasPrefix API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefix",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList": {
+				"description": "AliasPrefixList contains a list of AliasPrefix",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting": {
+				"description": "AliasPrefixRouting is the Schema for the aliasprefixrouting API",
+				"type": "object",
+				"required": [
+					"destinations"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"destinations": {
+						"description": "Destinations are the destinations for an AliasPrefix.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixRouting",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList": {
+				"description": "AliasPrefixRoutingList contains a list of AliasPrefixRouting",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixRoutingList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixSpec": {
+				"description": "AliasPrefixSpec defines the desired state of AliasPrefix",
+				"type": "object",
+				"required": [
+					"networkRef"
+				],
+				"properties": {
+					"networkInterfaceSelector": {
+						"description": "NetworkInterfaceSelector defines the NetworkInterfaces for which this AliasPrefix should be applied",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					},
+					"networkRef": {
+						"description": "NetworkRef is the Network this AliasPrefix should belong to",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the provided Prefix or Ephemeral which should be used by this AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.PrefixSource"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixStatus": {
+				"description": "AliasPrefixStatus defines the observed state of AliasPrefix",
+				"type": "object",
+				"properties": {
+					"prefix": {
+						"description": "Prefix is the Prefix reserved by this AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource": {
+				"description": "EphemeralPrefixSource contains the definition to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) Prefix.",
+				"type": "object",
+				"properties": {
+					"prefixTemplate": {
+						"description": "PrefixTemplate is the template for the Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralVirtualIPSource": {
+				"description": "EphemeralVirtualIPSource contains the definition to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) VirtualIP.",
+				"type": "object",
+				"properties": {
+					"virtualIPTemplate": {
+						"description": "VirtualIPTemplate is the template for the VirtualIP.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.IPSource": {
+				"description": "IPSource is the definition of how to obtain an IP.",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral specifies an IP by creating an ephemeral Prefix to allocate the IP with.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource"
+							}
+						]
+					},
+					"value": {
+						"description": "Value specifies an IP by using an IP literal.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network": {
+				"description": "Network is the Schema for the network API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "Network",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface": {
+				"description": "NetworkInterface is the Schema for the networkinterfaces API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkInterface",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList": {
+				"description": "NetworkInterfaceList contains a list of NetworkInterface",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkInterfaceList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec": {
+				"description": "NetworkInterfaceSpec defines the desired state of NetworkInterface",
+				"type": "object",
+				"required": [
+					"networkRef",
+					"ipFamilies",
+					"ips"
+				],
+				"properties": {
+					"ipFamilies": {
+						"description": "IPFamilies defines which IPFamilies this NetworkInterface is supporting",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"ips": {
+						"description": "IPs is the list of provided IPs or EphemeralIPs which should be assigned to this NetworkInterface",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.IPSource"
+						}
+					},
+					"machineRef": {
+						"description": "MachineRef is the Machine this NetworkInterface is used by",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"networkRef": {
+						"description": "NetworkRef is the Network this NetworkInterface is connected to",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"virtualIP": {
+						"description": "VirtualIP specifies the virtual ip that should be assigned to this NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSource"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceStatus": {
+				"description": "NetworkInterfaceStatus defines the observed state of NetworkInterface",
+				"type": "object",
+				"properties": {
+					"ips": {
+						"description": "IPs represent the effective IP addresses of the NetworkInterface",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+						}
+					},
+					"phase": {
+						"description": "Phase is the NetworkInterfacePhase of the NetworkInterface.",
+						"type": "string"
+					},
+					"phaseLastTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned from one value to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"virtualIP": {
+						"description": "VirtualIP is any virtual ip assigned to the NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceTemplateSpec": {
+				"description": "NetworkInterfaceTemplateSpec is the specification of a NetworkInterface template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList": {
+				"description": "NetworkList contains a list of Network",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.PrefixSource": {
+				"description": "PrefixSource is the source of the Prefix definition in an AliasPrefix",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral defines the Prefix which should be allocated by the AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource"
+							}
+						]
+					},
+					"value": {
+						"description": "Value is a single IPPrefix value as defined in the AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP": {
+				"description": "VirtualIP is the Schema for the virtualips API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "VirtualIP",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList": {
+				"description": "VirtualIPList contains a list of VirtualIP",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "VirtualIPList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSource": {
+				"description": "VirtualIPSource is the definition of how to obtain a VirtualIP.",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) VirtualIP.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralVirtualIPSource"
+							}
+						]
+					},
+					"virtualIPRef": {
+						"description": "VirtualIPRef references a VirtualIP to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec": {
+				"description": "VirtualIPSpec defines the desired state of VirtualIP",
+				"type": "object",
+				"required": [
+					"type",
+					"ipFamily"
+				],
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the ip family of the VirtualIP.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"targetRef": {
+						"description": "TargetRef references the target for this VirtualIP (currently only NetworkInterface).",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"type": {
+						"description": "Type is the type of VirtualIP.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPStatus": {
+				"description": "VirtualIPStatus defines the observed state of VirtualIP",
+				"type": "object",
+				"properties": {
+					"ip": {
+						"description": "IP is the allocated IP, if any.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the VirtualIPPhase of the VirtualIP.",
+						"type": "string"
+					},
+					"phaseLastTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned from one value to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPTemplateSpec": {
+				"description": "VirtualIPTemplateSpec is the specification of a VirtualIP template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume": {
+				"description": "Volume is the Schema for the volumes API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "Volume",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeAccess": {
+				"description": "VolumeAccess represents information on how to access a volume.",
+				"type": "object",
+				"required": [
+					"driver"
+				],
+				"properties": {
+					"driver": {
+						"description": "Driver is the name of the drive to use for this volume. Required.",
+						"type": "string"
+					},
+					"secretRef": {
+						"description": "SecretRef references the Secret containing the access credentials to consume a Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumeAttributes": {
+						"description": "VolumeAttributes are attributes of the volume to use.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass": {
+				"description": "VolumeClass is the Schema for the volumeclasses API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"capabilities": {
+						"description": "Capabilities describes the capabilities of a VolumeClass.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeClass",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList": {
+				"description": "VolumeClassList contains a list of VolumeClass",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeClassList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeCondition": {
+				"description": "VolumeCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList": {
+				"description": "VolumeList contains a list of Volume",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool": {
+				"description": "VolumePool is the Schema for the volumepools API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumePool",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolCondition": {
+				"description": "VolumePoolCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status",
+					"reason",
+					"message"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList": {
+				"description": "VolumePoolList contains a list of VolumePool",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumePoolList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolSpec": {
+				"description": "VolumePoolSpec defines the desired state of VolumePool",
+				"type": "object",
+				"required": [
+					"providerID"
+				],
+				"properties": {
+					"providerID": {
+						"description": "ProviderID identifies the VolumePool on provider side.",
+						"type": "string"
+					},
+					"taints": {
+						"description": "Taints of the VolumePool. Only Volumes who tolerate all the taints will land in the VolumePool.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolStatus": {
+				"description": "VolumePoolStatus defines the observed state of VolumePool",
+				"type": "object",
+				"properties": {
+					"available": {
+						"description": "Available list the available capacity of a VolumePool.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"availableVolumeClasses": {
+						"description": "AvailableVolumeClasses list the references of any supported VolumeClass of this pool",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+						}
+					},
+					"conditions": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolCondition"
+						}
+					},
+					"state": {
+						"type": "string"
+					},
+					"used": {
+						"description": "Used indicates how much capacity has been used in a VolumePool.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec": {
+				"description": "VolumeSpec defines the desired state of Volume",
+				"type": "object",
+				"required": [
+					"volumeClassRef"
+				],
+				"properties": {
+					"claimRef": {
+						"description": "ClaimRef is the reference to the claiming entity of the Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"image": {
+						"description": "Image is an optional image to bootstrap the volume with.",
+						"type": "string"
+					},
+					"imagePullSecretRef": {
+						"description": "ImagePullSecretRef is an optional secret for pulling the image of a volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"resources": {
+						"description": "Resources is a description of the volume's resources and capacity.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"tolerations": {
+						"description": "Tolerations define tolerations the Volume has. Only any VolumePool whose taints covered by Tolerations will be considered to host the Volume.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration"
+						}
+					},
+					"unclaimable": {
+						"description": "Unclaimable marks the volume as unclaimable.",
+						"type": "boolean"
+					},
+					"volumeClassRef": {
+						"description": "VolumeClassRef is the VolumeClass of a volume",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumePoolRef": {
+						"description": "VolumePoolRef indicates which VolumePool to use for a volume. If unset, the scheduler will figure out a suitable VolumePoolRef.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumePoolSelector": {
+						"description": "VolumePoolSelector selects a suitable VolumePoolRef by the given labels.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeStatus": {
+				"description": "VolumeStatus defines the observed state of Volume",
+				"type": "object",
+				"properties": {
+					"access": {
+						"description": "Access specifies how to access a Volume. This is set by the volume provider when the volume is provisioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeAccess"
+							}
+						]
+					},
+					"conditions": {
+						"description": "Conditions are the conditions of a volume.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeCondition"
+						}
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned between values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"lastStateTransitionTime": {
+						"description": "LastStateTransitionTime is the last time the State transitioned between values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase represents the binding phase of a Volume.",
+						"type": "string"
+					},
+					"state": {
+						"description": "State represents the infrastructure state of a Volume.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeTemplateSpec": {
+				"description": "VolumeTemplateSpec is the specification of a Volume template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec"
+					}
+				}
+			},
+			"io.k8s.api.core.v1.LocalObjectReference": {
+				"description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+				"type": "object",
+				"properties": {
+					"name": {
+						"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.api.resource.Quantity": {
+				"description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n\u003cquantity\u003e        ::= \u003csignedNumber\u003e\u003csuffix\u003e\n  (Note that \u003csuffix\u003e may be empty, from the \"\" case in \u003cdecimalSI\u003e.)\n\u003cdigit\u003e           ::= 0 | 1 | ... | 9 \u003cdigits\u003e          ::= \u003cdigit\u003e | \u003cdigit\u003e\u003cdigits\u003e \u003cnumber\u003e          ::= \u003cdigits\u003e | \u003cdigits\u003e.\u003cdigits\u003e | \u003cdigits\u003e. | .\u003cdigits\u003e \u003csign\u003e            ::= \"+\" | \"-\" \u003csignedNumber\u003e    ::= \u003cnumber\u003e | \u003csign\u003e\u003cnumber\u003e \u003csuffix\u003e          ::= \u003cbinarySI\u003e | \u003cdecimalExponent\u003e | \u003cdecimalSI\u003e \u003cbinarySI\u003e        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\u003cdecimalSI\u003e       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\u003cdecimalExponent\u003e ::= \"e\" \u003csignedNumber\u003e | \"E\" \u003csignedNumber\u003e\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+				"type": "string"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup": {
+				"description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+				"type": "object",
+				"required": [
+					"name",
+					"versions"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "name is the name of the group.",
+						"type": "string"
+					},
+					"preferredVersion": {
+						"description": "preferredVersion is the version preferred by the API server, which probably is the storage version.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+							}
+						]
+					},
+					"serverAddressByClientCIDRs": {
+						"description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
+						}
+					},
+					"versions": {
+						"description": "versions are the versions supported in this group.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+						}
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIGroup",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList": {
+				"description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+				"type": "object",
+				"required": [
+					"groups"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"groups": {
+						"description": "groups is a list of APIGroup.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIGroupList",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
+				"description": "APIResource specifies the name of a resource and whether it is namespaced.",
+				"type": "object",
+				"required": [
+					"name",
+					"singularName",
+					"namespaced",
+					"kind",
+					"verbs"
+				],
+				"properties": {
+					"categories": {
+						"description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"group": {
+						"description": "group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale\".",
+						"type": "string"
+					},
+					"kind": {
+						"description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+						"type": "string"
+					},
+					"name": {
+						"description": "name is the plural name of the resource.",
+						"type": "string"
+					},
+					"namespaced": {
+						"description": "namespaced indicates if a resource is namespaced or not.",
+						"type": "boolean"
+					},
+					"shortNames": {
+						"description": "shortNames is a list of suggested short names of the resource.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"singularName": {
+						"description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
+						"type": "string"
+					},
+					"storageVersionHash": {
+						"description": "The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.",
+						"type": "string"
+					},
+					"verbs": {
+						"description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"version": {
+						"description": "version is the preferred version of the resource.  Empty implies the version of the containing resource list For subresources, this may have a different value, for example: v1 (while inside a v1beta1 version of the core resource's group)\".",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+				"description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+				"type": "object",
+				"required": [
+					"groupVersion",
+					"resources"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"groupVersion": {
+						"description": "groupVersion is the group and version this APIResourceList is for.",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"resources": {
+						"description": "resources contains the name of the resources and if they are namespaced.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
+						}
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIResourceList",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+				"description": "DeleteOptions may be provided when deleting an API object.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"dryRun": {
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"gracePeriodSeconds": {
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"orphanDependents": {
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"type": "boolean"
+					},
+					"preconditions": {
+						"description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+							}
+						]
+					},
+					"propagationPolicy": {
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "DeleteOptions",
+						"version": "v1"
+					},
+					{
+						"group": "autoscaling",
+						"kind": "DeleteOptions",
+						"version": "v1"
+					},
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+				"description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
+				"description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+				"type": "object",
+				"required": [
+					"groupVersion",
+					"version"
+				],
+				"properties": {
+					"groupVersion": {
+						"description": "groupVersion specifies the API group and version in the form \"group/version\"",
+						"type": "string"
+					},
+					"version": {
+						"description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+				"description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+				"type": "object",
+				"properties": {
+					"matchExpressions": {
+						"description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+						}
+					},
+					"matchLabels": {
+						"description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+				"description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+				"type": "object",
+				"required": [
+					"key",
+					"operator"
+				],
+				"properties": {
+					"key": {
+						"description": "key is the label key that the selector applies to.",
+						"type": "string",
+						"x-kubernetes-patch-merge-key": "key",
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"operator": {
+						"description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+						"type": "string"
+					},
+					"values": {
+						"description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+				"description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+				"type": "object",
+				"properties": {
+					"continue": {
+						"description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+						"type": "string"
+					},
+					"remainingItemCount": {
+						"description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"resourceVersion": {
+						"description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+						"type": "string"
+					},
+					"selfLink": {
+						"description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+				"description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+						"type": "string"
+					},
+					"fieldsType": {
+						"description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+						"type": "string"
+					},
+					"fieldsV1": {
+						"description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+							}
+						]
+					},
+					"manager": {
+						"description": "Manager is an identifier of the workflow managing these fields.",
+						"type": "string"
+					},
+					"operation": {
+						"description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+						"type": "string"
+					},
+					"subresource": {
+						"description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+						"type": "string"
+					},
+					"time": {
+						"description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+				"description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+				"type": "object",
+				"properties": {
+					"annotations": {
+						"description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"clusterName": {
+						"description": "Deprecated: ClusterName is a legacy field that was always cleared by the system and never used; it will be removed completely in 1.25.\n\nThe name in the go struct is changed to help clients detect accidental use.",
+						"type": "string"
+					},
+					"creationTimestamp": {
+						"description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"deletionGracePeriodSeconds": {
+						"description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"deletionTimestamp": {
+						"description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"finalizers": {
+						"description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"generateName": {
+						"description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+						"type": "string"
+					},
+					"generation": {
+						"description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"labels": {
+						"description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"managedFields": {
+						"description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+						}
+					},
+					"name": {
+						"description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+						"type": "string"
+					},
+					"namespace": {
+						"description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+						"type": "string"
+					},
+					"ownerReferences": {
+						"description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+						},
+						"x-kubernetes-patch-merge-key": "uid",
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"resourceVersion": {
+						"description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+						"type": "string"
+					},
+					"selfLink": {
+						"description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+				"description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+				"type": "object",
+				"required": [
+					"apiVersion",
+					"kind",
+					"name",
+					"uid"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "API version of the referent.",
+						"type": "string"
+					},
+					"blockOwnerDeletion": {
+						"description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+						"type": "boolean"
+					},
+					"controller": {
+						"description": "If true, this reference points to the managing controller.",
+						"type": "boolean"
+					},
+					"kind": {
+						"description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+				"description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+				"description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+				"type": "object",
+				"properties": {
+					"resourceVersion": {
+						"description": "Specifies the target ResourceVersion",
+						"type": "string"
+					},
+					"uid": {
+						"description": "Specifies the target UID.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR": {
+				"description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+				"type": "object",
+				"required": [
+					"clientCIDR",
+					"serverAddress"
+				],
+				"properties": {
+					"clientCIDR": {
+						"description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+						"type": "string"
+					},
+					"serverAddress": {
+						"description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+				"description": "Status is a return value for calls that don't return other objects.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"code": {
+						"description": "Suggested HTTP return code for this status, 0 if not set.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"details": {
+						"description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
+							}
+						]
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"message": {
+						"description": "A human-readable description of the status of this operation.",
+						"type": "string"
+					},
+					"metadata": {
+						"description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+							}
+						]
+					},
+					"reason": {
+						"description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "Status",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+				"description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+				"type": "object",
+				"properties": {
+					"field": {
+						"description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+						"type": "string"
+					},
+					"message": {
+						"description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+						"type": "string"
+					},
+					"reason": {
+						"description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+				"description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+				"type": "object",
+				"properties": {
+					"causes": {
+						"description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+						}
+					},
+					"group": {
+						"description": "The group attribute of the resource associated with the status StatusReason.",
+						"type": "string"
+					},
+					"kind": {
+						"description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+						"type": "string"
+					},
+					"retryAfterSeconds": {
+						"description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"uid": {
+						"description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+				"description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+				"type": "string",
+				"format": "date-time"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+				"description": "Event represents a single event to a watched resource.",
+				"type": "object",
+				"required": [
+					"type",
+					"object"
+				],
+				"properties": {
+					"object": {
+						"description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
+							}
+						]
+					},
+					"type": {
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "WatchEvent",
+						"version": "v1"
+					},
+					{
+						"group": "autoscaling",
+						"kind": "WatchEvent",
+						"version": "v1"
+					},
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.runtime.RawExtension": {
+				"description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.version.Info": {
+				"description": "Info contains versioning information. how we'll want to distribute that information.",
+				"type": "object",
+				"required": [
+					"major",
+					"minor",
+					"gitVersion",
+					"gitCommit",
+					"gitTreeState",
+					"buildDate",
+					"goVersion",
+					"compiler",
+					"platform"
+				],
+				"properties": {
+					"buildDate": {
+						"type": "string"
+					},
+					"compiler": {
+						"type": "string"
+					},
+					"gitCommit": {
+						"type": "string"
+					},
+					"gitTreeState": {
+						"type": "string"
+					},
+					"gitVersion": {
+						"type": "string"
+					},
+					"goVersion": {
+						"type": "string"
+					},
+					"major": {
+						"type": "string"
+					},
+					"minor": {
+						"type": "string"
+					},
+					"platform": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"securitySchemes": {
+			"BearerToken": {
+				"type": "apiKey",
+				"description": "Bearer Token authentication",
+				"name": "authorization",
+				"in": "header"
+			}
+		}
+	}
+}

--- a/gen/v3/apis__ipam.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__ipam.api.onmetal.de__v1alpha1_openapi.json
@@ -1,0 +1,20902 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"title": "onmetal-api",
+		"version": "0.1"
+	},
+	"paths": {
+		"/apis/": {
+			"get": {
+				"tags": [
+					"apis"
+				],
+				"description": "get available API versions",
+				"operationId": "getAPIVersions",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getComputeApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getComputeApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machineclasses": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind MachineClass",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a MachineClass",
+				"operationId": "createComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of MachineClass",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionMachineClass",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machineclasses/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified MachineClass",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachineClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified MachineClass",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a MachineClass",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified MachineClass",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind MachinePool",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a MachinePool",
+				"operationId": "createComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of MachinePool",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionMachinePool",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified MachinePool",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachinePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified MachinePool",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a MachinePool",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified MachinePool",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools/{name}/status": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified MachinePool",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified MachinePool",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified MachinePool",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Machine",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachineForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Machine",
+				"operationId": "listComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Machine",
+				"operationId": "createComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Machine",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionNamespacedMachine",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Machine",
+				"operationId": "readComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Machine",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Machine",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Machine",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}/exec": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "connect GET requests to exec of Machine",
+				"operationId": "connectComputeApiOnmetalDeV1alpha1GetNamespacedMachineExec",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "connect",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineExecOptions",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "connect POST requests to exec of Machine",
+				"operationId": "connectComputeApiOnmetalDeV1alpha1PostNamespacedMachineExec",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "connect",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineExecOptions",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "insecureSkipTLSVerifyBackend",
+					"in": "query",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineExecOptions",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}/status": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Machine",
+				"operationId": "readComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Machine",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Machine",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machineclasses": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of MachineClass. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineClassList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machineclasses/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind MachineClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machinepools": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of MachinePool. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachinePoolList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machinepools/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind MachinePool. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachinePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Machine. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Machine. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1NamespacedMachineList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/machines/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Machine. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getIpamApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getIpamApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind PrefixAllocation",
+				"operationId": "listIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a PrefixAllocation",
+				"operationId": "createIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of PrefixAllocation",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1CollectionNamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified PrefixAllocation",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified PrefixAllocation",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a PrefixAllocation",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified PrefixAllocation",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations/{name}/status": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified PrefixAllocation",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified PrefixAllocation",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified PrefixAllocation",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Prefix",
+				"operationId": "listIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Prefix",
+				"operationId": "createIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Prefix",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1CollectionNamespacedPrefix",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Prefix",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Prefix",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Prefix",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Prefix",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes/{name}/status": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Prefix",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Prefix",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Prefix",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind PrefixAllocation",
+				"operationId": "listIpamApiOnmetalDeV1alpha1PrefixAllocationForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Prefix",
+				"operationId": "listIpamApiOnmetalDeV1alpha1PrefixForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixallocations/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Prefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixes/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Prefix. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1PrefixAllocationListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Prefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1PrefixListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getNetworkingApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getNetworkingApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefix",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1AliasPrefixForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefixRouting",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1AliasPrefixRoutingForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefix",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create an AliasPrefix",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of AliasPrefix",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified AliasPrefix",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified AliasPrefix",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete an AliasPrefix",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified AliasPrefix",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified AliasPrefix",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified AliasPrefix",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified AliasPrefix",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefixRouting",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create an AliasPrefixRouting",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of AliasPrefixRouting",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixroutings/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified AliasPrefixRouting",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified AliasPrefixRouting",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete an AliasPrefixRouting",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified AliasPrefixRouting",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefixRouting",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind NetworkInterface",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a NetworkInterface",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of NetworkInterface",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified NetworkInterface",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified NetworkInterface",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a NetworkInterface",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified NetworkInterface",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified NetworkInterface",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified NetworkInterface",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified NetworkInterface",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Network",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Network",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Network",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedNetwork",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networks/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Network",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Network",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Network",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Network",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Network",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VirtualIP",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VirtualIP",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VirtualIP",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VirtualIP",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VirtualIP",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VirtualIP",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VirtualIP",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified VirtualIP",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified VirtualIP",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified VirtualIP",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind NetworkInterface",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NetworkInterfaceForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Network",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NetworkForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VirtualIP",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1VirtualIPForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1AliasPrefixListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1AliasPrefixRoutingListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixes/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRoutingList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixroutings/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefixRouting",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networkinterfaces/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Network. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networks/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Network. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Network",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VirtualIP. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/virtualips/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VirtualIP. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NetworkInterfaceListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Network. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NetworkListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VirtualIP. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1VirtualIPListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getStorageApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getStorageApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Volume",
+				"operationId": "listStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Volume",
+				"operationId": "createStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Volume",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionNamespacedVolume",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Volume",
+				"operationId": "readStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Volume",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Volume",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Volume",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes/{name}/status": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Volume",
+				"operationId": "readStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Volume",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Volume",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumeclasses": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VolumeClass",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VolumeClass",
+				"operationId": "createStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VolumeClass",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionVolumeClass",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumeclasses/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VolumeClass",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumeClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VolumeClass",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VolumeClass",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VolumeClass",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumeClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VolumePool",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VolumePool",
+				"operationId": "createStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VolumePool",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionVolumePool",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VolumePool",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VolumePool",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VolumePool",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VolumePool",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools/{name}/status": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified VolumePool",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified VolumePool",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified VolumePool",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Volume",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumeForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Volume. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1NamespacedVolumeList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/volumes/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Volume. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumeclasses": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VolumeClass. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeClassList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumeclasses/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VolumeClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumeClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumepools": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VolumePool. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumePoolList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumepools/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VolumePool. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Volume. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/version/": {
+			"get": {
+				"tags": [
+					"version"
+				],
+				"description": "get the code version",
+				"operationId": "getCodeVersion",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.version.Info"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP": {
+				"description": "IP is an IP address.",
+				"type": "string",
+				"format": "ip"
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix": {
+				"description": "IPPrefix represents a network prefix.",
+				"type": "string",
+				"format": "ip-prefix"
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference": {
+				"description": "LocalUIDReference is a reference to another entity including its UID",
+				"type": "object",
+				"required": [
+					"name",
+					"uid"
+				],
+				"properties": {
+					"name": {
+						"description": "Name is the name of the referenced entity.",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID is the UID of the referenced entity.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.SecretKeySelector": {
+				"description": "SecretKeySelector is a reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+				"type": "object",
+				"properties": {
+					"key": {
+						"description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+						"type": "string"
+					},
+					"name": {
+						"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint": {
+				"description": "The resource pool this Taint is attached to has the \"effect\" on any resource that does not tolerate the Taint.",
+				"type": "object",
+				"required": [
+					"key",
+					"effect"
+				],
+				"properties": {
+					"effect": {
+						"description": "The effect of the taint on resources that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+						"type": "string"
+					},
+					"key": {
+						"description": "The taint key to be applied to a resource pool.",
+						"type": "string"
+					},
+					"value": {
+						"description": "The taint value corresponding to the taint key.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration": {
+				"description": "The resource this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+				"type": "object",
+				"properties": {
+					"effect": {
+						"description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule.",
+						"type": "string"
+					},
+					"key": {
+						"description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+						"type": "string"
+					},
+					"operator": {
+						"description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a resource can tolerate all taints of a particular category.",
+						"type": "string"
+					},
+					"value": {
+						"description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.DaemonEndpoint": {
+				"description": "DaemonEndpoint contains information about a single Daemon endpoint.",
+				"type": "object",
+				"required": [
+					"port"
+				],
+				"properties": {
+					"port": {
+						"description": "Port number of the given endpoint.",
+						"type": "integer",
+						"format": "int32"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EFIVar": {
+				"description": "EFIVar is a variable to pass to EFI while booting up.",
+				"type": "object",
+				"required": [
+					"name",
+					"uuid",
+					"value"
+				],
+				"properties": {
+					"name": {
+						"description": "Name is the name of the EFIVar.",
+						"type": "string"
+					},
+					"uuid": {
+						"description": "UUID is the uuid of the EFIVar.",
+						"type": "string"
+					},
+					"value": {
+						"description": "Value is the value of the EFIVar.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EmptyDiskVolumeSource": {
+				"description": "EmptyDiskVolumeSource is a volume that's offered by the machine pool provider. Usually ephemeral (i.e. deleted when the surrounding entity is deleted), with varying performance characteristics. Potentially not recoverable.",
+				"type": "object",
+				"properties": {
+					"sizeLimit": {
+						"description": "SizeLimit is the total amount of local storage required for this EmptyDisk volume. The default is nil which means that the limit is undefined.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralNetworkInterfaceSource": {
+				"description": "EphemeralNetworkInterfaceSource is a definition for an ephemeral (i.e. coupled to the lifetime of the surrounding object) networking.NetworkInterface.",
+				"type": "object",
+				"properties": {
+					"networkInterfaceTemplate": {
+						"description": "NetworkInterfaceTemplate is the template definition of the networking.NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralVolumeSource": {
+				"description": "EphemeralVolumeSource is a definition for an ephemeral (i.e. coupled to the lifetime of the surrounding object) storage.Volume.",
+				"type": "object",
+				"properties": {
+					"volumeTemplate": {
+						"description": "VolumeTemplate is the template definition of the storage.Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine": {
+				"description": "Machine is the Schema for the machines API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "Machine",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass": {
+				"description": "MachineClass is the Schema for the machineclasses API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"capabilities": {
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineClass",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList": {
+				"description": "MachineClassList contains a list of MachineClass",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineClassList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineCondition": {
+				"description": "MachineCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList": {
+				"description": "MachineList contains a list of Machine",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool": {
+				"description": "MachinePool is the Schema for the machinepools API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachinePool",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolAddress": {
+				"type": "object",
+				"required": [
+					"type",
+					"address"
+				],
+				"properties": {
+					"address": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolCondition": {
+				"description": "MachinePoolCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status",
+					"reason",
+					"message"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolDaemonEndpoints": {
+				"description": "MachinePoolDaemonEndpoints lists ports opened by daemons running on the MachinePool.",
+				"type": "object",
+				"properties": {
+					"machinepoolletEndpoint": {
+						"description": "Endpoint on which machinepoollet is listening.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.DaemonEndpoint"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList": {
+				"description": "MachinePoolList contains a list of MachinePool",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachinePoolList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolSpec": {
+				"description": "MachinePoolSpec defines the desired state of MachinePool",
+				"type": "object",
+				"required": [
+					"providerID"
+				],
+				"properties": {
+					"providerID": {
+						"description": "ProviderID identifies the MachinePool on provider side.",
+						"type": "string"
+					},
+					"taints": {
+						"description": "Taints of the MachinePool. Only Machines who tolerate all the taints will land in the MachinePool.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolStatus": {
+				"description": "MachinePoolStatus defines the observed state of MachinePool",
+				"type": "object",
+				"properties": {
+					"addresses": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolAddress"
+						}
+					},
+					"availableMachineClasses": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+						}
+					},
+					"conditions": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolCondition"
+						}
+					},
+					"daemonEndpoints": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolDaemonEndpoints"
+					},
+					"state": {
+						"description": "Possible enum values:\n - `\"Error\"` marks a MachinePool in an error state.\n - `\"Offline\"` marks a MachinePool as offline.\n - `\"Pending\"` marks a MachinePool as pending readiness.\n - `\"Ready\"` marks a MachinePool as ready for accepting a Machine.",
+						"type": "string",
+						"enum": [
+							"Error",
+							"Offline",
+							"Pending",
+							"Ready"
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineSpec": {
+				"description": "MachineSpec defines the desired state of Machine",
+				"type": "object",
+				"required": [
+					"machineClassRef",
+					"image"
+				],
+				"properties": {
+					"efiVars": {
+						"description": "EFIVars are variables to pass to EFI while booting up.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EFIVar"
+						}
+					},
+					"ignitionRef": {
+						"description": "IgnitionRef is a reference to a config map containing the ignition YAML for the machine to boot up. If key is empty, DefaultIgnitionKey will be used as fallback.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.SecretKeySelector"
+							}
+						]
+					},
+					"image": {
+						"description": "Image is the URL providing the operating system image of the machine.",
+						"type": "string"
+					},
+					"imagePullSecret": {
+						"description": "ImagePullSecretRef is an optional secret for pulling the image of a machine.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machineClassRef": {
+						"description": "MachineClassRef is a reference to the machine class/flavor of the machine.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machinePoolRef": {
+						"description": "MachinePoolRef defines machine pool to run the machine in. If empty, a scheduler will figure out an appropriate pool to run the machine in.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machinePoolSelector": {
+						"description": "MachinePoolSelector selects a suitable MachinePoolRef by the given labels.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"networkInterfaces": {
+						"description": "NetworkInterfaces define a list of network interfaces present on the machine",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterface"
+						}
+					},
+					"tolerations": {
+						"description": "Tolerations define tolerations the Machine has. Only MachinePools whose taints covered by Tolerations will be considered to run the Machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration"
+						}
+					},
+					"volumes": {
+						"description": "Volumes are volumes attached to this machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Volume"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineStatus": {
+				"description": "MachineStatus defines the observed state of Machine",
+				"type": "object",
+				"properties": {
+					"conditions": {
+						"description": "Conditions are the conditions of the machines.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineCondition"
+						}
+					},
+					"networkInterfaces": {
+						"description": "NetworkInterfaces is the list of network interface states for the machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterfaceStatus"
+						}
+					},
+					"state": {
+						"description": "State is the state of the machine.\n\nPossible enum values:\n - `\"Error\"` means the machine is in an error state.\n - `\"Pending\"` means the Machine has been accepted by the system, but not yet completely started. This includes time before being bound to a MachinePool, as well as time spent setting up the Machine on that MachinePool.\n - `\"Running\"` means the machine is running on a MachinePool.\n - `\"Shutdown\"` means the machine is shut down.",
+						"type": "string",
+						"enum": [
+							"Error",
+							"Pending",
+							"Running",
+							"Shutdown"
+						]
+					},
+					"volumes": {
+						"description": "Volumes is the list of volume states for the machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.VolumeStatus"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterface": {
+				"description": "NetworkInterface is the definition of a single interface",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) NetworkInterface to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralNetworkInterfaceSource"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the network interface.",
+						"type": "string"
+					},
+					"networkInterfaceRef": {
+						"description": "NetworkInterfaceRef instructs to use the NetworkInterface at the target reference.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterfaceStatus": {
+				"description": "NetworkInterfaceStatus reports the status of an NetworkInterfaceSource.",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"ips": {
+						"description": "IPs are the ips allocated for the network interface.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+						}
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the NetworkInterface to whom the status belongs to.",
+						"type": "string"
+					},
+					"phase": {
+						"description": "Phase is the NetworkInterface binding phase of the NetworkInterface.",
+						"type": "string"
+					},
+					"virtualIP": {
+						"description": "VirtualIP is the virtual ip allocated for the network interface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Volume": {
+				"description": "Volume defines a volume attachment of a machine",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"device": {
+						"description": "Device is the device name where the volume should be attached. If empty, an unused device name will be determined if possible.",
+						"type": "string"
+					},
+					"emptyDisk": {
+						"description": "EmptyDisk instructs to use a Volume offered by the machine pool provider.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EmptyDiskVolumeSource"
+							}
+						]
+					},
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) Volume to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralVolumeSource"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the Volume",
+						"type": "string"
+					},
+					"volumeRef": {
+						"description": "VolumeRef instructs to use the specified Volume as source for the attachment.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.VolumeStatus": {
+				"description": "VolumeStatus is the status of a Volume.",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"deviceID": {
+						"description": "DeviceID is the disk device ID on the host.",
+						"type": "string"
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of a volume attachment.",
+						"type": "string"
+					},
+					"phase": {
+						"description": "Phase represents the binding phase of a Volume.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix": {
+				"description": "Prefix is the Schema for the prefixes API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "Prefix",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation": {
+				"description": "PrefixAllocation is the Schema for the prefixallocations API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixAllocation",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList": {
+				"description": "PrefixAllocationList contains a list of PrefixAllocation",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixAllocationList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationSpec": {
+				"description": "PrefixAllocationSpec defines the desired state of PrefixAllocation",
+				"type": "object",
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the IPFamily of the prefix. If unset but Prefix is set, this can be inferred.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the prefix to allocate for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					},
+					"prefixLength": {
+						"description": "PrefixLength is the length of prefix to allocate for this Prefix.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"prefixRef": {
+						"description": "PrefixRef references the prefix to allocate from.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"prefixSelector": {
+						"description": "PrefixSelector selects the prefix to allocate from.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationStatus": {
+				"description": "PrefixAllocationStatus is the status of a PrefixAllocation.",
+				"type": "object",
+				"properties": {
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase changed values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the phase of the PrefixAllocation.",
+						"type": "string"
+					},
+					"prefix": {
+						"description": "Prefix is the allocated prefix, if any",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList": {
+				"description": "PrefixList contains a list of Prefix",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec": {
+				"description": "PrefixSpec defines the desired state of Prefix",
+				"type": "object",
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the IPFamily of the prefix. If unset but Prefix is set, this can be inferred.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"parentRef": {
+						"description": "ParentRef references the parent to allocate the Prefix from. If ParentRef and ParentSelector is empty, the Prefix is considered a root prefix and thus allocated by itself.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"parentSelector": {
+						"description": "ParentSelector is the LabelSelector to use for determining the parent for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the prefix to allocate for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					},
+					"prefixLength": {
+						"description": "PrefixLength is the length of prefix to allocate for this Prefix.",
+						"type": "integer",
+						"format": "int32"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixStatus": {
+				"description": "PrefixStatus defines the observed state of Prefix",
+				"type": "object",
+				"properties": {
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase changed values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the PrefixPhase of the Prefix.",
+						"type": "string"
+					},
+					"used": {
+						"description": "Used is a list of used prefixes.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixTemplateSpec": {
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix": {
+				"description": "AliasPrefix is the Schema for the AliasPrefix API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefix",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList": {
+				"description": "AliasPrefixList contains a list of AliasPrefix",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting": {
+				"description": "AliasPrefixRouting is the Schema for the aliasprefixrouting API",
+				"type": "object",
+				"required": [
+					"destinations"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"destinations": {
+						"description": "Destinations are the destinations for an AliasPrefix.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixRouting",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList": {
+				"description": "AliasPrefixRoutingList contains a list of AliasPrefixRouting",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixRoutingList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixSpec": {
+				"description": "AliasPrefixSpec defines the desired state of AliasPrefix",
+				"type": "object",
+				"required": [
+					"networkRef"
+				],
+				"properties": {
+					"networkInterfaceSelector": {
+						"description": "NetworkInterfaceSelector defines the NetworkInterfaces for which this AliasPrefix should be applied",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					},
+					"networkRef": {
+						"description": "NetworkRef is the Network this AliasPrefix should belong to",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the provided Prefix or Ephemeral which should be used by this AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.PrefixSource"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixStatus": {
+				"description": "AliasPrefixStatus defines the observed state of AliasPrefix",
+				"type": "object",
+				"properties": {
+					"prefix": {
+						"description": "Prefix is the Prefix reserved by this AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource": {
+				"description": "EphemeralPrefixSource contains the definition to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) Prefix.",
+				"type": "object",
+				"properties": {
+					"prefixTemplate": {
+						"description": "PrefixTemplate is the template for the Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralVirtualIPSource": {
+				"description": "EphemeralVirtualIPSource contains the definition to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) VirtualIP.",
+				"type": "object",
+				"properties": {
+					"virtualIPTemplate": {
+						"description": "VirtualIPTemplate is the template for the VirtualIP.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.IPSource": {
+				"description": "IPSource is the definition of how to obtain an IP.",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral specifies an IP by creating an ephemeral Prefix to allocate the IP with.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource"
+							}
+						]
+					},
+					"value": {
+						"description": "Value specifies an IP by using an IP literal.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network": {
+				"description": "Network is the Schema for the network API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "Network",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface": {
+				"description": "NetworkInterface is the Schema for the networkinterfaces API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkInterface",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList": {
+				"description": "NetworkInterfaceList contains a list of NetworkInterface",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkInterfaceList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec": {
+				"description": "NetworkInterfaceSpec defines the desired state of NetworkInterface",
+				"type": "object",
+				"required": [
+					"networkRef",
+					"ipFamilies",
+					"ips"
+				],
+				"properties": {
+					"ipFamilies": {
+						"description": "IPFamilies defines which IPFamilies this NetworkInterface is supporting",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"ips": {
+						"description": "IPs is the list of provided IPs or EphemeralIPs which should be assigned to this NetworkInterface",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.IPSource"
+						}
+					},
+					"machineRef": {
+						"description": "MachineRef is the Machine this NetworkInterface is used by",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"networkRef": {
+						"description": "NetworkRef is the Network this NetworkInterface is connected to",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"virtualIP": {
+						"description": "VirtualIP specifies the virtual ip that should be assigned to this NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSource"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceStatus": {
+				"description": "NetworkInterfaceStatus defines the observed state of NetworkInterface",
+				"type": "object",
+				"properties": {
+					"ips": {
+						"description": "IPs represent the effective IP addresses of the NetworkInterface",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+						}
+					},
+					"phase": {
+						"description": "Phase is the NetworkInterfacePhase of the NetworkInterface.",
+						"type": "string"
+					},
+					"phaseLastTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned from one value to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"virtualIP": {
+						"description": "VirtualIP is any virtual ip assigned to the NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceTemplateSpec": {
+				"description": "NetworkInterfaceTemplateSpec is the specification of a NetworkInterface template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList": {
+				"description": "NetworkList contains a list of Network",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.PrefixSource": {
+				"description": "PrefixSource is the source of the Prefix definition in an AliasPrefix",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral defines the Prefix which should be allocated by the AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource"
+							}
+						]
+					},
+					"value": {
+						"description": "Value is a single IPPrefix value as defined in the AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP": {
+				"description": "VirtualIP is the Schema for the virtualips API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "VirtualIP",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList": {
+				"description": "VirtualIPList contains a list of VirtualIP",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "VirtualIPList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSource": {
+				"description": "VirtualIPSource is the definition of how to obtain a VirtualIP.",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) VirtualIP.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralVirtualIPSource"
+							}
+						]
+					},
+					"virtualIPRef": {
+						"description": "VirtualIPRef references a VirtualIP to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec": {
+				"description": "VirtualIPSpec defines the desired state of VirtualIP",
+				"type": "object",
+				"required": [
+					"type",
+					"ipFamily"
+				],
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the ip family of the VirtualIP.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"targetRef": {
+						"description": "TargetRef references the target for this VirtualIP (currently only NetworkInterface).",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"type": {
+						"description": "Type is the type of VirtualIP.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPStatus": {
+				"description": "VirtualIPStatus defines the observed state of VirtualIP",
+				"type": "object",
+				"properties": {
+					"ip": {
+						"description": "IP is the allocated IP, if any.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the VirtualIPPhase of the VirtualIP.",
+						"type": "string"
+					},
+					"phaseLastTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned from one value to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPTemplateSpec": {
+				"description": "VirtualIPTemplateSpec is the specification of a VirtualIP template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume": {
+				"description": "Volume is the Schema for the volumes API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "Volume",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeAccess": {
+				"description": "VolumeAccess represents information on how to access a volume.",
+				"type": "object",
+				"required": [
+					"driver"
+				],
+				"properties": {
+					"driver": {
+						"description": "Driver is the name of the drive to use for this volume. Required.",
+						"type": "string"
+					},
+					"secretRef": {
+						"description": "SecretRef references the Secret containing the access credentials to consume a Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumeAttributes": {
+						"description": "VolumeAttributes are attributes of the volume to use.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass": {
+				"description": "VolumeClass is the Schema for the volumeclasses API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"capabilities": {
+						"description": "Capabilities describes the capabilities of a VolumeClass.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeClass",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList": {
+				"description": "VolumeClassList contains a list of VolumeClass",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeClassList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeCondition": {
+				"description": "VolumeCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList": {
+				"description": "VolumeList contains a list of Volume",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool": {
+				"description": "VolumePool is the Schema for the volumepools API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumePool",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolCondition": {
+				"description": "VolumePoolCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status",
+					"reason",
+					"message"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList": {
+				"description": "VolumePoolList contains a list of VolumePool",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumePoolList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolSpec": {
+				"description": "VolumePoolSpec defines the desired state of VolumePool",
+				"type": "object",
+				"required": [
+					"providerID"
+				],
+				"properties": {
+					"providerID": {
+						"description": "ProviderID identifies the VolumePool on provider side.",
+						"type": "string"
+					},
+					"taints": {
+						"description": "Taints of the VolumePool. Only Volumes who tolerate all the taints will land in the VolumePool.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolStatus": {
+				"description": "VolumePoolStatus defines the observed state of VolumePool",
+				"type": "object",
+				"properties": {
+					"available": {
+						"description": "Available list the available capacity of a VolumePool.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"availableVolumeClasses": {
+						"description": "AvailableVolumeClasses list the references of any supported VolumeClass of this pool",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+						}
+					},
+					"conditions": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolCondition"
+						}
+					},
+					"state": {
+						"type": "string"
+					},
+					"used": {
+						"description": "Used indicates how much capacity has been used in a VolumePool.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec": {
+				"description": "VolumeSpec defines the desired state of Volume",
+				"type": "object",
+				"required": [
+					"volumeClassRef"
+				],
+				"properties": {
+					"claimRef": {
+						"description": "ClaimRef is the reference to the claiming entity of the Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"image": {
+						"description": "Image is an optional image to bootstrap the volume with.",
+						"type": "string"
+					},
+					"imagePullSecretRef": {
+						"description": "ImagePullSecretRef is an optional secret for pulling the image of a volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"resources": {
+						"description": "Resources is a description of the volume's resources and capacity.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"tolerations": {
+						"description": "Tolerations define tolerations the Volume has. Only any VolumePool whose taints covered by Tolerations will be considered to host the Volume.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration"
+						}
+					},
+					"unclaimable": {
+						"description": "Unclaimable marks the volume as unclaimable.",
+						"type": "boolean"
+					},
+					"volumeClassRef": {
+						"description": "VolumeClassRef is the VolumeClass of a volume",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumePoolRef": {
+						"description": "VolumePoolRef indicates which VolumePool to use for a volume. If unset, the scheduler will figure out a suitable VolumePoolRef.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumePoolSelector": {
+						"description": "VolumePoolSelector selects a suitable VolumePoolRef by the given labels.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeStatus": {
+				"description": "VolumeStatus defines the observed state of Volume",
+				"type": "object",
+				"properties": {
+					"access": {
+						"description": "Access specifies how to access a Volume. This is set by the volume provider when the volume is provisioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeAccess"
+							}
+						]
+					},
+					"conditions": {
+						"description": "Conditions are the conditions of a volume.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeCondition"
+						}
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned between values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"lastStateTransitionTime": {
+						"description": "LastStateTransitionTime is the last time the State transitioned between values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase represents the binding phase of a Volume.",
+						"type": "string"
+					},
+					"state": {
+						"description": "State represents the infrastructure state of a Volume.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeTemplateSpec": {
+				"description": "VolumeTemplateSpec is the specification of a Volume template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec"
+					}
+				}
+			},
+			"io.k8s.api.core.v1.LocalObjectReference": {
+				"description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+				"type": "object",
+				"properties": {
+					"name": {
+						"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.api.resource.Quantity": {
+				"description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n\u003cquantity\u003e        ::= \u003csignedNumber\u003e\u003csuffix\u003e\n  (Note that \u003csuffix\u003e may be empty, from the \"\" case in \u003cdecimalSI\u003e.)\n\u003cdigit\u003e           ::= 0 | 1 | ... | 9 \u003cdigits\u003e          ::= \u003cdigit\u003e | \u003cdigit\u003e\u003cdigits\u003e \u003cnumber\u003e          ::= \u003cdigits\u003e | \u003cdigits\u003e.\u003cdigits\u003e | \u003cdigits\u003e. | .\u003cdigits\u003e \u003csign\u003e            ::= \"+\" | \"-\" \u003csignedNumber\u003e    ::= \u003cnumber\u003e | \u003csign\u003e\u003cnumber\u003e \u003csuffix\u003e          ::= \u003cbinarySI\u003e | \u003cdecimalExponent\u003e | \u003cdecimalSI\u003e \u003cbinarySI\u003e        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\u003cdecimalSI\u003e       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\u003cdecimalExponent\u003e ::= \"e\" \u003csignedNumber\u003e | \"E\" \u003csignedNumber\u003e\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+				"type": "string"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup": {
+				"description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+				"type": "object",
+				"required": [
+					"name",
+					"versions"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "name is the name of the group.",
+						"type": "string"
+					},
+					"preferredVersion": {
+						"description": "preferredVersion is the version preferred by the API server, which probably is the storage version.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+							}
+						]
+					},
+					"serverAddressByClientCIDRs": {
+						"description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
+						}
+					},
+					"versions": {
+						"description": "versions are the versions supported in this group.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+						}
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIGroup",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList": {
+				"description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+				"type": "object",
+				"required": [
+					"groups"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"groups": {
+						"description": "groups is a list of APIGroup.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIGroupList",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
+				"description": "APIResource specifies the name of a resource and whether it is namespaced.",
+				"type": "object",
+				"required": [
+					"name",
+					"singularName",
+					"namespaced",
+					"kind",
+					"verbs"
+				],
+				"properties": {
+					"categories": {
+						"description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"group": {
+						"description": "group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale\".",
+						"type": "string"
+					},
+					"kind": {
+						"description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+						"type": "string"
+					},
+					"name": {
+						"description": "name is the plural name of the resource.",
+						"type": "string"
+					},
+					"namespaced": {
+						"description": "namespaced indicates if a resource is namespaced or not.",
+						"type": "boolean"
+					},
+					"shortNames": {
+						"description": "shortNames is a list of suggested short names of the resource.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"singularName": {
+						"description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
+						"type": "string"
+					},
+					"storageVersionHash": {
+						"description": "The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.",
+						"type": "string"
+					},
+					"verbs": {
+						"description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"version": {
+						"description": "version is the preferred version of the resource.  Empty implies the version of the containing resource list For subresources, this may have a different value, for example: v1 (while inside a v1beta1 version of the core resource's group)\".",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+				"description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+				"type": "object",
+				"required": [
+					"groupVersion",
+					"resources"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"groupVersion": {
+						"description": "groupVersion is the group and version this APIResourceList is for.",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"resources": {
+						"description": "resources contains the name of the resources and if they are namespaced.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
+						}
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIResourceList",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+				"description": "DeleteOptions may be provided when deleting an API object.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"dryRun": {
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"gracePeriodSeconds": {
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"orphanDependents": {
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"type": "boolean"
+					},
+					"preconditions": {
+						"description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+							}
+						]
+					},
+					"propagationPolicy": {
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "DeleteOptions",
+						"version": "v1"
+					},
+					{
+						"group": "autoscaling",
+						"kind": "DeleteOptions",
+						"version": "v1"
+					},
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+				"description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
+				"description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+				"type": "object",
+				"required": [
+					"groupVersion",
+					"version"
+				],
+				"properties": {
+					"groupVersion": {
+						"description": "groupVersion specifies the API group and version in the form \"group/version\"",
+						"type": "string"
+					},
+					"version": {
+						"description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+				"description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+				"type": "object",
+				"properties": {
+					"matchExpressions": {
+						"description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+						}
+					},
+					"matchLabels": {
+						"description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+				"description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+				"type": "object",
+				"required": [
+					"key",
+					"operator"
+				],
+				"properties": {
+					"key": {
+						"description": "key is the label key that the selector applies to.",
+						"type": "string",
+						"x-kubernetes-patch-merge-key": "key",
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"operator": {
+						"description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+						"type": "string"
+					},
+					"values": {
+						"description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+				"description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+				"type": "object",
+				"properties": {
+					"continue": {
+						"description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+						"type": "string"
+					},
+					"remainingItemCount": {
+						"description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"resourceVersion": {
+						"description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+						"type": "string"
+					},
+					"selfLink": {
+						"description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+				"description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+						"type": "string"
+					},
+					"fieldsType": {
+						"description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+						"type": "string"
+					},
+					"fieldsV1": {
+						"description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+							}
+						]
+					},
+					"manager": {
+						"description": "Manager is an identifier of the workflow managing these fields.",
+						"type": "string"
+					},
+					"operation": {
+						"description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+						"type": "string"
+					},
+					"subresource": {
+						"description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+						"type": "string"
+					},
+					"time": {
+						"description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+				"description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+				"type": "object",
+				"properties": {
+					"annotations": {
+						"description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"clusterName": {
+						"description": "Deprecated: ClusterName is a legacy field that was always cleared by the system and never used; it will be removed completely in 1.25.\n\nThe name in the go struct is changed to help clients detect accidental use.",
+						"type": "string"
+					},
+					"creationTimestamp": {
+						"description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"deletionGracePeriodSeconds": {
+						"description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"deletionTimestamp": {
+						"description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"finalizers": {
+						"description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"generateName": {
+						"description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+						"type": "string"
+					},
+					"generation": {
+						"description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"labels": {
+						"description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"managedFields": {
+						"description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+						}
+					},
+					"name": {
+						"description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+						"type": "string"
+					},
+					"namespace": {
+						"description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+						"type": "string"
+					},
+					"ownerReferences": {
+						"description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+						},
+						"x-kubernetes-patch-merge-key": "uid",
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"resourceVersion": {
+						"description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+						"type": "string"
+					},
+					"selfLink": {
+						"description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+				"description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+				"type": "object",
+				"required": [
+					"apiVersion",
+					"kind",
+					"name",
+					"uid"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "API version of the referent.",
+						"type": "string"
+					},
+					"blockOwnerDeletion": {
+						"description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+						"type": "boolean"
+					},
+					"controller": {
+						"description": "If true, this reference points to the managing controller.",
+						"type": "boolean"
+					},
+					"kind": {
+						"description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+				"description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+				"description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+				"type": "object",
+				"properties": {
+					"resourceVersion": {
+						"description": "Specifies the target ResourceVersion",
+						"type": "string"
+					},
+					"uid": {
+						"description": "Specifies the target UID.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR": {
+				"description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+				"type": "object",
+				"required": [
+					"clientCIDR",
+					"serverAddress"
+				],
+				"properties": {
+					"clientCIDR": {
+						"description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+						"type": "string"
+					},
+					"serverAddress": {
+						"description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+				"description": "Status is a return value for calls that don't return other objects.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"code": {
+						"description": "Suggested HTTP return code for this status, 0 if not set.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"details": {
+						"description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
+							}
+						]
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"message": {
+						"description": "A human-readable description of the status of this operation.",
+						"type": "string"
+					},
+					"metadata": {
+						"description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+							}
+						]
+					},
+					"reason": {
+						"description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "Status",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+				"description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+				"type": "object",
+				"properties": {
+					"field": {
+						"description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+						"type": "string"
+					},
+					"message": {
+						"description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+						"type": "string"
+					},
+					"reason": {
+						"description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+				"description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+				"type": "object",
+				"properties": {
+					"causes": {
+						"description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+						}
+					},
+					"group": {
+						"description": "The group attribute of the resource associated with the status StatusReason.",
+						"type": "string"
+					},
+					"kind": {
+						"description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+						"type": "string"
+					},
+					"retryAfterSeconds": {
+						"description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"uid": {
+						"description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+				"description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+				"type": "string",
+				"format": "date-time"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+				"description": "Event represents a single event to a watched resource.",
+				"type": "object",
+				"required": [
+					"type",
+					"object"
+				],
+				"properties": {
+					"object": {
+						"description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
+							}
+						]
+					},
+					"type": {
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "WatchEvent",
+						"version": "v1"
+					},
+					{
+						"group": "autoscaling",
+						"kind": "WatchEvent",
+						"version": "v1"
+					},
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.runtime.RawExtension": {
+				"description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.version.Info": {
+				"description": "Info contains versioning information. how we'll want to distribute that information.",
+				"type": "object",
+				"required": [
+					"major",
+					"minor",
+					"gitVersion",
+					"gitCommit",
+					"gitTreeState",
+					"buildDate",
+					"goVersion",
+					"compiler",
+					"platform"
+				],
+				"properties": {
+					"buildDate": {
+						"type": "string"
+					},
+					"compiler": {
+						"type": "string"
+					},
+					"gitCommit": {
+						"type": "string"
+					},
+					"gitTreeState": {
+						"type": "string"
+					},
+					"gitVersion": {
+						"type": "string"
+					},
+					"goVersion": {
+						"type": "string"
+					},
+					"major": {
+						"type": "string"
+					},
+					"minor": {
+						"type": "string"
+					},
+					"platform": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"securitySchemes": {
+			"BearerToken": {
+				"type": "apiKey",
+				"description": "Bearer Token authentication",
+				"name": "authorization",
+				"in": "header"
+			}
+		}
+	}
+}

--- a/gen/v3/apis__networking.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__networking.api.onmetal.de__v1alpha1_openapi.json
@@ -1,0 +1,20902 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"title": "onmetal-api",
+		"version": "0.1"
+	},
+	"paths": {
+		"/apis/": {
+			"get": {
+				"tags": [
+					"apis"
+				],
+				"description": "get available API versions",
+				"operationId": "getAPIVersions",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getComputeApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getComputeApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machineclasses": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind MachineClass",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a MachineClass",
+				"operationId": "createComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of MachineClass",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionMachineClass",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machineclasses/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified MachineClass",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachineClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified MachineClass",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a MachineClass",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified MachineClass",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind MachinePool",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a MachinePool",
+				"operationId": "createComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of MachinePool",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionMachinePool",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified MachinePool",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachinePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified MachinePool",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a MachinePool",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified MachinePool",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools/{name}/status": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified MachinePool",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified MachinePool",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified MachinePool",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Machine",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachineForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Machine",
+				"operationId": "listComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Machine",
+				"operationId": "createComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Machine",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionNamespacedMachine",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Machine",
+				"operationId": "readComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Machine",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Machine",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Machine",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}/exec": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "connect GET requests to exec of Machine",
+				"operationId": "connectComputeApiOnmetalDeV1alpha1GetNamespacedMachineExec",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "connect",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineExecOptions",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "connect POST requests to exec of Machine",
+				"operationId": "connectComputeApiOnmetalDeV1alpha1PostNamespacedMachineExec",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "connect",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineExecOptions",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "insecureSkipTLSVerifyBackend",
+					"in": "query",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineExecOptions",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}/status": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Machine",
+				"operationId": "readComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Machine",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Machine",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machineclasses": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of MachineClass. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineClassList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machineclasses/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind MachineClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machinepools": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of MachinePool. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachinePoolList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machinepools/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind MachinePool. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachinePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Machine. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Machine. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1NamespacedMachineList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/machines/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Machine. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getIpamApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getIpamApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind PrefixAllocation",
+				"operationId": "listIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a PrefixAllocation",
+				"operationId": "createIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of PrefixAllocation",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1CollectionNamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified PrefixAllocation",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified PrefixAllocation",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a PrefixAllocation",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified PrefixAllocation",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations/{name}/status": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified PrefixAllocation",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified PrefixAllocation",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified PrefixAllocation",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Prefix",
+				"operationId": "listIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Prefix",
+				"operationId": "createIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Prefix",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1CollectionNamespacedPrefix",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Prefix",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Prefix",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Prefix",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Prefix",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes/{name}/status": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Prefix",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Prefix",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Prefix",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind PrefixAllocation",
+				"operationId": "listIpamApiOnmetalDeV1alpha1PrefixAllocationForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Prefix",
+				"operationId": "listIpamApiOnmetalDeV1alpha1PrefixForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixallocations/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Prefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixes/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Prefix. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1PrefixAllocationListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Prefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1PrefixListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getNetworkingApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getNetworkingApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefix",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1AliasPrefixForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefixRouting",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1AliasPrefixRoutingForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefix",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create an AliasPrefix",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of AliasPrefix",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified AliasPrefix",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified AliasPrefix",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete an AliasPrefix",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified AliasPrefix",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified AliasPrefix",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified AliasPrefix",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified AliasPrefix",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefixRouting",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create an AliasPrefixRouting",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of AliasPrefixRouting",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixroutings/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified AliasPrefixRouting",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified AliasPrefixRouting",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete an AliasPrefixRouting",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified AliasPrefixRouting",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefixRouting",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind NetworkInterface",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a NetworkInterface",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of NetworkInterface",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified NetworkInterface",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified NetworkInterface",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a NetworkInterface",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified NetworkInterface",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified NetworkInterface",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified NetworkInterface",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified NetworkInterface",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Network",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Network",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Network",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedNetwork",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networks/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Network",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Network",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Network",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Network",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Network",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VirtualIP",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VirtualIP",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VirtualIP",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VirtualIP",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VirtualIP",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VirtualIP",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VirtualIP",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified VirtualIP",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified VirtualIP",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified VirtualIP",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind NetworkInterface",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NetworkInterfaceForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Network",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NetworkForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VirtualIP",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1VirtualIPForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1AliasPrefixListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1AliasPrefixRoutingListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixes/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRoutingList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixroutings/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefixRouting",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networkinterfaces/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Network. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networks/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Network. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Network",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VirtualIP. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/virtualips/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VirtualIP. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NetworkInterfaceListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Network. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NetworkListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VirtualIP. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1VirtualIPListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getStorageApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getStorageApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Volume",
+				"operationId": "listStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Volume",
+				"operationId": "createStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Volume",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionNamespacedVolume",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Volume",
+				"operationId": "readStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Volume",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Volume",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Volume",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes/{name}/status": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Volume",
+				"operationId": "readStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Volume",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Volume",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumeclasses": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VolumeClass",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VolumeClass",
+				"operationId": "createStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VolumeClass",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionVolumeClass",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumeclasses/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VolumeClass",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumeClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VolumeClass",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VolumeClass",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VolumeClass",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumeClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VolumePool",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VolumePool",
+				"operationId": "createStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VolumePool",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionVolumePool",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VolumePool",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VolumePool",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VolumePool",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VolumePool",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools/{name}/status": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified VolumePool",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified VolumePool",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified VolumePool",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Volume",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumeForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Volume. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1NamespacedVolumeList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/volumes/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Volume. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumeclasses": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VolumeClass. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeClassList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumeclasses/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VolumeClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumeClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumepools": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VolumePool. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumePoolList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumepools/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VolumePool. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Volume. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/version/": {
+			"get": {
+				"tags": [
+					"version"
+				],
+				"description": "get the code version",
+				"operationId": "getCodeVersion",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.version.Info"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP": {
+				"description": "IP is an IP address.",
+				"type": "string",
+				"format": "ip"
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix": {
+				"description": "IPPrefix represents a network prefix.",
+				"type": "string",
+				"format": "ip-prefix"
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference": {
+				"description": "LocalUIDReference is a reference to another entity including its UID",
+				"type": "object",
+				"required": [
+					"name",
+					"uid"
+				],
+				"properties": {
+					"name": {
+						"description": "Name is the name of the referenced entity.",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID is the UID of the referenced entity.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.SecretKeySelector": {
+				"description": "SecretKeySelector is a reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+				"type": "object",
+				"properties": {
+					"key": {
+						"description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+						"type": "string"
+					},
+					"name": {
+						"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint": {
+				"description": "The resource pool this Taint is attached to has the \"effect\" on any resource that does not tolerate the Taint.",
+				"type": "object",
+				"required": [
+					"key",
+					"effect"
+				],
+				"properties": {
+					"effect": {
+						"description": "The effect of the taint on resources that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+						"type": "string"
+					},
+					"key": {
+						"description": "The taint key to be applied to a resource pool.",
+						"type": "string"
+					},
+					"value": {
+						"description": "The taint value corresponding to the taint key.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration": {
+				"description": "The resource this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+				"type": "object",
+				"properties": {
+					"effect": {
+						"description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule.",
+						"type": "string"
+					},
+					"key": {
+						"description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+						"type": "string"
+					},
+					"operator": {
+						"description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a resource can tolerate all taints of a particular category.",
+						"type": "string"
+					},
+					"value": {
+						"description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.DaemonEndpoint": {
+				"description": "DaemonEndpoint contains information about a single Daemon endpoint.",
+				"type": "object",
+				"required": [
+					"port"
+				],
+				"properties": {
+					"port": {
+						"description": "Port number of the given endpoint.",
+						"type": "integer",
+						"format": "int32"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EFIVar": {
+				"description": "EFIVar is a variable to pass to EFI while booting up.",
+				"type": "object",
+				"required": [
+					"name",
+					"uuid",
+					"value"
+				],
+				"properties": {
+					"name": {
+						"description": "Name is the name of the EFIVar.",
+						"type": "string"
+					},
+					"uuid": {
+						"description": "UUID is the uuid of the EFIVar.",
+						"type": "string"
+					},
+					"value": {
+						"description": "Value is the value of the EFIVar.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EmptyDiskVolumeSource": {
+				"description": "EmptyDiskVolumeSource is a volume that's offered by the machine pool provider. Usually ephemeral (i.e. deleted when the surrounding entity is deleted), with varying performance characteristics. Potentially not recoverable.",
+				"type": "object",
+				"properties": {
+					"sizeLimit": {
+						"description": "SizeLimit is the total amount of local storage required for this EmptyDisk volume. The default is nil which means that the limit is undefined.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralNetworkInterfaceSource": {
+				"description": "EphemeralNetworkInterfaceSource is a definition for an ephemeral (i.e. coupled to the lifetime of the surrounding object) networking.NetworkInterface.",
+				"type": "object",
+				"properties": {
+					"networkInterfaceTemplate": {
+						"description": "NetworkInterfaceTemplate is the template definition of the networking.NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralVolumeSource": {
+				"description": "EphemeralVolumeSource is a definition for an ephemeral (i.e. coupled to the lifetime of the surrounding object) storage.Volume.",
+				"type": "object",
+				"properties": {
+					"volumeTemplate": {
+						"description": "VolumeTemplate is the template definition of the storage.Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine": {
+				"description": "Machine is the Schema for the machines API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "Machine",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass": {
+				"description": "MachineClass is the Schema for the machineclasses API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"capabilities": {
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineClass",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList": {
+				"description": "MachineClassList contains a list of MachineClass",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineClassList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineCondition": {
+				"description": "MachineCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList": {
+				"description": "MachineList contains a list of Machine",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool": {
+				"description": "MachinePool is the Schema for the machinepools API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachinePool",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolAddress": {
+				"type": "object",
+				"required": [
+					"type",
+					"address"
+				],
+				"properties": {
+					"address": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolCondition": {
+				"description": "MachinePoolCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status",
+					"reason",
+					"message"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolDaemonEndpoints": {
+				"description": "MachinePoolDaemonEndpoints lists ports opened by daemons running on the MachinePool.",
+				"type": "object",
+				"properties": {
+					"machinepoolletEndpoint": {
+						"description": "Endpoint on which machinepoollet is listening.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.DaemonEndpoint"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList": {
+				"description": "MachinePoolList contains a list of MachinePool",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachinePoolList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolSpec": {
+				"description": "MachinePoolSpec defines the desired state of MachinePool",
+				"type": "object",
+				"required": [
+					"providerID"
+				],
+				"properties": {
+					"providerID": {
+						"description": "ProviderID identifies the MachinePool on provider side.",
+						"type": "string"
+					},
+					"taints": {
+						"description": "Taints of the MachinePool. Only Machines who tolerate all the taints will land in the MachinePool.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolStatus": {
+				"description": "MachinePoolStatus defines the observed state of MachinePool",
+				"type": "object",
+				"properties": {
+					"addresses": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolAddress"
+						}
+					},
+					"availableMachineClasses": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+						}
+					},
+					"conditions": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolCondition"
+						}
+					},
+					"daemonEndpoints": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolDaemonEndpoints"
+					},
+					"state": {
+						"description": "Possible enum values:\n - `\"Error\"` marks a MachinePool in an error state.\n - `\"Offline\"` marks a MachinePool as offline.\n - `\"Pending\"` marks a MachinePool as pending readiness.\n - `\"Ready\"` marks a MachinePool as ready for accepting a Machine.",
+						"type": "string",
+						"enum": [
+							"Error",
+							"Offline",
+							"Pending",
+							"Ready"
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineSpec": {
+				"description": "MachineSpec defines the desired state of Machine",
+				"type": "object",
+				"required": [
+					"machineClassRef",
+					"image"
+				],
+				"properties": {
+					"efiVars": {
+						"description": "EFIVars are variables to pass to EFI while booting up.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EFIVar"
+						}
+					},
+					"ignitionRef": {
+						"description": "IgnitionRef is a reference to a config map containing the ignition YAML for the machine to boot up. If key is empty, DefaultIgnitionKey will be used as fallback.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.SecretKeySelector"
+							}
+						]
+					},
+					"image": {
+						"description": "Image is the URL providing the operating system image of the machine.",
+						"type": "string"
+					},
+					"imagePullSecret": {
+						"description": "ImagePullSecretRef is an optional secret for pulling the image of a machine.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machineClassRef": {
+						"description": "MachineClassRef is a reference to the machine class/flavor of the machine.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machinePoolRef": {
+						"description": "MachinePoolRef defines machine pool to run the machine in. If empty, a scheduler will figure out an appropriate pool to run the machine in.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machinePoolSelector": {
+						"description": "MachinePoolSelector selects a suitable MachinePoolRef by the given labels.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"networkInterfaces": {
+						"description": "NetworkInterfaces define a list of network interfaces present on the machine",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterface"
+						}
+					},
+					"tolerations": {
+						"description": "Tolerations define tolerations the Machine has. Only MachinePools whose taints covered by Tolerations will be considered to run the Machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration"
+						}
+					},
+					"volumes": {
+						"description": "Volumes are volumes attached to this machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Volume"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineStatus": {
+				"description": "MachineStatus defines the observed state of Machine",
+				"type": "object",
+				"properties": {
+					"conditions": {
+						"description": "Conditions are the conditions of the machines.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineCondition"
+						}
+					},
+					"networkInterfaces": {
+						"description": "NetworkInterfaces is the list of network interface states for the machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterfaceStatus"
+						}
+					},
+					"state": {
+						"description": "State is the state of the machine.\n\nPossible enum values:\n - `\"Error\"` means the machine is in an error state.\n - `\"Pending\"` means the Machine has been accepted by the system, but not yet completely started. This includes time before being bound to a MachinePool, as well as time spent setting up the Machine on that MachinePool.\n - `\"Running\"` means the machine is running on a MachinePool.\n - `\"Shutdown\"` means the machine is shut down.",
+						"type": "string",
+						"enum": [
+							"Error",
+							"Pending",
+							"Running",
+							"Shutdown"
+						]
+					},
+					"volumes": {
+						"description": "Volumes is the list of volume states for the machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.VolumeStatus"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterface": {
+				"description": "NetworkInterface is the definition of a single interface",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) NetworkInterface to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralNetworkInterfaceSource"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the network interface.",
+						"type": "string"
+					},
+					"networkInterfaceRef": {
+						"description": "NetworkInterfaceRef instructs to use the NetworkInterface at the target reference.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterfaceStatus": {
+				"description": "NetworkInterfaceStatus reports the status of an NetworkInterfaceSource.",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"ips": {
+						"description": "IPs are the ips allocated for the network interface.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+						}
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the NetworkInterface to whom the status belongs to.",
+						"type": "string"
+					},
+					"phase": {
+						"description": "Phase is the NetworkInterface binding phase of the NetworkInterface.",
+						"type": "string"
+					},
+					"virtualIP": {
+						"description": "VirtualIP is the virtual ip allocated for the network interface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Volume": {
+				"description": "Volume defines a volume attachment of a machine",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"device": {
+						"description": "Device is the device name where the volume should be attached. If empty, an unused device name will be determined if possible.",
+						"type": "string"
+					},
+					"emptyDisk": {
+						"description": "EmptyDisk instructs to use a Volume offered by the machine pool provider.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EmptyDiskVolumeSource"
+							}
+						]
+					},
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) Volume to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralVolumeSource"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the Volume",
+						"type": "string"
+					},
+					"volumeRef": {
+						"description": "VolumeRef instructs to use the specified Volume as source for the attachment.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.VolumeStatus": {
+				"description": "VolumeStatus is the status of a Volume.",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"deviceID": {
+						"description": "DeviceID is the disk device ID on the host.",
+						"type": "string"
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of a volume attachment.",
+						"type": "string"
+					},
+					"phase": {
+						"description": "Phase represents the binding phase of a Volume.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix": {
+				"description": "Prefix is the Schema for the prefixes API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "Prefix",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation": {
+				"description": "PrefixAllocation is the Schema for the prefixallocations API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixAllocation",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList": {
+				"description": "PrefixAllocationList contains a list of PrefixAllocation",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixAllocationList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationSpec": {
+				"description": "PrefixAllocationSpec defines the desired state of PrefixAllocation",
+				"type": "object",
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the IPFamily of the prefix. If unset but Prefix is set, this can be inferred.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the prefix to allocate for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					},
+					"prefixLength": {
+						"description": "PrefixLength is the length of prefix to allocate for this Prefix.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"prefixRef": {
+						"description": "PrefixRef references the prefix to allocate from.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"prefixSelector": {
+						"description": "PrefixSelector selects the prefix to allocate from.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationStatus": {
+				"description": "PrefixAllocationStatus is the status of a PrefixAllocation.",
+				"type": "object",
+				"properties": {
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase changed values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the phase of the PrefixAllocation.",
+						"type": "string"
+					},
+					"prefix": {
+						"description": "Prefix is the allocated prefix, if any",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList": {
+				"description": "PrefixList contains a list of Prefix",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec": {
+				"description": "PrefixSpec defines the desired state of Prefix",
+				"type": "object",
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the IPFamily of the prefix. If unset but Prefix is set, this can be inferred.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"parentRef": {
+						"description": "ParentRef references the parent to allocate the Prefix from. If ParentRef and ParentSelector is empty, the Prefix is considered a root prefix and thus allocated by itself.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"parentSelector": {
+						"description": "ParentSelector is the LabelSelector to use for determining the parent for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the prefix to allocate for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					},
+					"prefixLength": {
+						"description": "PrefixLength is the length of prefix to allocate for this Prefix.",
+						"type": "integer",
+						"format": "int32"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixStatus": {
+				"description": "PrefixStatus defines the observed state of Prefix",
+				"type": "object",
+				"properties": {
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase changed values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the PrefixPhase of the Prefix.",
+						"type": "string"
+					},
+					"used": {
+						"description": "Used is a list of used prefixes.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixTemplateSpec": {
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix": {
+				"description": "AliasPrefix is the Schema for the AliasPrefix API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefix",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList": {
+				"description": "AliasPrefixList contains a list of AliasPrefix",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting": {
+				"description": "AliasPrefixRouting is the Schema for the aliasprefixrouting API",
+				"type": "object",
+				"required": [
+					"destinations"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"destinations": {
+						"description": "Destinations are the destinations for an AliasPrefix.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixRouting",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList": {
+				"description": "AliasPrefixRoutingList contains a list of AliasPrefixRouting",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixRoutingList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixSpec": {
+				"description": "AliasPrefixSpec defines the desired state of AliasPrefix",
+				"type": "object",
+				"required": [
+					"networkRef"
+				],
+				"properties": {
+					"networkInterfaceSelector": {
+						"description": "NetworkInterfaceSelector defines the NetworkInterfaces for which this AliasPrefix should be applied",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					},
+					"networkRef": {
+						"description": "NetworkRef is the Network this AliasPrefix should belong to",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the provided Prefix or Ephemeral which should be used by this AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.PrefixSource"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixStatus": {
+				"description": "AliasPrefixStatus defines the observed state of AliasPrefix",
+				"type": "object",
+				"properties": {
+					"prefix": {
+						"description": "Prefix is the Prefix reserved by this AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource": {
+				"description": "EphemeralPrefixSource contains the definition to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) Prefix.",
+				"type": "object",
+				"properties": {
+					"prefixTemplate": {
+						"description": "PrefixTemplate is the template for the Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralVirtualIPSource": {
+				"description": "EphemeralVirtualIPSource contains the definition to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) VirtualIP.",
+				"type": "object",
+				"properties": {
+					"virtualIPTemplate": {
+						"description": "VirtualIPTemplate is the template for the VirtualIP.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.IPSource": {
+				"description": "IPSource is the definition of how to obtain an IP.",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral specifies an IP by creating an ephemeral Prefix to allocate the IP with.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource"
+							}
+						]
+					},
+					"value": {
+						"description": "Value specifies an IP by using an IP literal.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network": {
+				"description": "Network is the Schema for the network API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "Network",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface": {
+				"description": "NetworkInterface is the Schema for the networkinterfaces API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkInterface",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList": {
+				"description": "NetworkInterfaceList contains a list of NetworkInterface",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkInterfaceList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec": {
+				"description": "NetworkInterfaceSpec defines the desired state of NetworkInterface",
+				"type": "object",
+				"required": [
+					"networkRef",
+					"ipFamilies",
+					"ips"
+				],
+				"properties": {
+					"ipFamilies": {
+						"description": "IPFamilies defines which IPFamilies this NetworkInterface is supporting",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"ips": {
+						"description": "IPs is the list of provided IPs or EphemeralIPs which should be assigned to this NetworkInterface",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.IPSource"
+						}
+					},
+					"machineRef": {
+						"description": "MachineRef is the Machine this NetworkInterface is used by",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"networkRef": {
+						"description": "NetworkRef is the Network this NetworkInterface is connected to",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"virtualIP": {
+						"description": "VirtualIP specifies the virtual ip that should be assigned to this NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSource"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceStatus": {
+				"description": "NetworkInterfaceStatus defines the observed state of NetworkInterface",
+				"type": "object",
+				"properties": {
+					"ips": {
+						"description": "IPs represent the effective IP addresses of the NetworkInterface",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+						}
+					},
+					"phase": {
+						"description": "Phase is the NetworkInterfacePhase of the NetworkInterface.",
+						"type": "string"
+					},
+					"phaseLastTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned from one value to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"virtualIP": {
+						"description": "VirtualIP is any virtual ip assigned to the NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceTemplateSpec": {
+				"description": "NetworkInterfaceTemplateSpec is the specification of a NetworkInterface template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList": {
+				"description": "NetworkList contains a list of Network",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.PrefixSource": {
+				"description": "PrefixSource is the source of the Prefix definition in an AliasPrefix",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral defines the Prefix which should be allocated by the AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource"
+							}
+						]
+					},
+					"value": {
+						"description": "Value is a single IPPrefix value as defined in the AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP": {
+				"description": "VirtualIP is the Schema for the virtualips API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "VirtualIP",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList": {
+				"description": "VirtualIPList contains a list of VirtualIP",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "VirtualIPList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSource": {
+				"description": "VirtualIPSource is the definition of how to obtain a VirtualIP.",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) VirtualIP.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralVirtualIPSource"
+							}
+						]
+					},
+					"virtualIPRef": {
+						"description": "VirtualIPRef references a VirtualIP to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec": {
+				"description": "VirtualIPSpec defines the desired state of VirtualIP",
+				"type": "object",
+				"required": [
+					"type",
+					"ipFamily"
+				],
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the ip family of the VirtualIP.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"targetRef": {
+						"description": "TargetRef references the target for this VirtualIP (currently only NetworkInterface).",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"type": {
+						"description": "Type is the type of VirtualIP.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPStatus": {
+				"description": "VirtualIPStatus defines the observed state of VirtualIP",
+				"type": "object",
+				"properties": {
+					"ip": {
+						"description": "IP is the allocated IP, if any.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the VirtualIPPhase of the VirtualIP.",
+						"type": "string"
+					},
+					"phaseLastTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned from one value to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPTemplateSpec": {
+				"description": "VirtualIPTemplateSpec is the specification of a VirtualIP template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume": {
+				"description": "Volume is the Schema for the volumes API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "Volume",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeAccess": {
+				"description": "VolumeAccess represents information on how to access a volume.",
+				"type": "object",
+				"required": [
+					"driver"
+				],
+				"properties": {
+					"driver": {
+						"description": "Driver is the name of the drive to use for this volume. Required.",
+						"type": "string"
+					},
+					"secretRef": {
+						"description": "SecretRef references the Secret containing the access credentials to consume a Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumeAttributes": {
+						"description": "VolumeAttributes are attributes of the volume to use.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass": {
+				"description": "VolumeClass is the Schema for the volumeclasses API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"capabilities": {
+						"description": "Capabilities describes the capabilities of a VolumeClass.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeClass",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList": {
+				"description": "VolumeClassList contains a list of VolumeClass",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeClassList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeCondition": {
+				"description": "VolumeCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList": {
+				"description": "VolumeList contains a list of Volume",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool": {
+				"description": "VolumePool is the Schema for the volumepools API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumePool",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolCondition": {
+				"description": "VolumePoolCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status",
+					"reason",
+					"message"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList": {
+				"description": "VolumePoolList contains a list of VolumePool",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumePoolList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolSpec": {
+				"description": "VolumePoolSpec defines the desired state of VolumePool",
+				"type": "object",
+				"required": [
+					"providerID"
+				],
+				"properties": {
+					"providerID": {
+						"description": "ProviderID identifies the VolumePool on provider side.",
+						"type": "string"
+					},
+					"taints": {
+						"description": "Taints of the VolumePool. Only Volumes who tolerate all the taints will land in the VolumePool.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolStatus": {
+				"description": "VolumePoolStatus defines the observed state of VolumePool",
+				"type": "object",
+				"properties": {
+					"available": {
+						"description": "Available list the available capacity of a VolumePool.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"availableVolumeClasses": {
+						"description": "AvailableVolumeClasses list the references of any supported VolumeClass of this pool",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+						}
+					},
+					"conditions": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolCondition"
+						}
+					},
+					"state": {
+						"type": "string"
+					},
+					"used": {
+						"description": "Used indicates how much capacity has been used in a VolumePool.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec": {
+				"description": "VolumeSpec defines the desired state of Volume",
+				"type": "object",
+				"required": [
+					"volumeClassRef"
+				],
+				"properties": {
+					"claimRef": {
+						"description": "ClaimRef is the reference to the claiming entity of the Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"image": {
+						"description": "Image is an optional image to bootstrap the volume with.",
+						"type": "string"
+					},
+					"imagePullSecretRef": {
+						"description": "ImagePullSecretRef is an optional secret for pulling the image of a volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"resources": {
+						"description": "Resources is a description of the volume's resources and capacity.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"tolerations": {
+						"description": "Tolerations define tolerations the Volume has. Only any VolumePool whose taints covered by Tolerations will be considered to host the Volume.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration"
+						}
+					},
+					"unclaimable": {
+						"description": "Unclaimable marks the volume as unclaimable.",
+						"type": "boolean"
+					},
+					"volumeClassRef": {
+						"description": "VolumeClassRef is the VolumeClass of a volume",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumePoolRef": {
+						"description": "VolumePoolRef indicates which VolumePool to use for a volume. If unset, the scheduler will figure out a suitable VolumePoolRef.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumePoolSelector": {
+						"description": "VolumePoolSelector selects a suitable VolumePoolRef by the given labels.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeStatus": {
+				"description": "VolumeStatus defines the observed state of Volume",
+				"type": "object",
+				"properties": {
+					"access": {
+						"description": "Access specifies how to access a Volume. This is set by the volume provider when the volume is provisioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeAccess"
+							}
+						]
+					},
+					"conditions": {
+						"description": "Conditions are the conditions of a volume.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeCondition"
+						}
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned between values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"lastStateTransitionTime": {
+						"description": "LastStateTransitionTime is the last time the State transitioned between values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase represents the binding phase of a Volume.",
+						"type": "string"
+					},
+					"state": {
+						"description": "State represents the infrastructure state of a Volume.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeTemplateSpec": {
+				"description": "VolumeTemplateSpec is the specification of a Volume template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec"
+					}
+				}
+			},
+			"io.k8s.api.core.v1.LocalObjectReference": {
+				"description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+				"type": "object",
+				"properties": {
+					"name": {
+						"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.api.resource.Quantity": {
+				"description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n\u003cquantity\u003e        ::= \u003csignedNumber\u003e\u003csuffix\u003e\n  (Note that \u003csuffix\u003e may be empty, from the \"\" case in \u003cdecimalSI\u003e.)\n\u003cdigit\u003e           ::= 0 | 1 | ... | 9 \u003cdigits\u003e          ::= \u003cdigit\u003e | \u003cdigit\u003e\u003cdigits\u003e \u003cnumber\u003e          ::= \u003cdigits\u003e | \u003cdigits\u003e.\u003cdigits\u003e | \u003cdigits\u003e. | .\u003cdigits\u003e \u003csign\u003e            ::= \"+\" | \"-\" \u003csignedNumber\u003e    ::= \u003cnumber\u003e | \u003csign\u003e\u003cnumber\u003e \u003csuffix\u003e          ::= \u003cbinarySI\u003e | \u003cdecimalExponent\u003e | \u003cdecimalSI\u003e \u003cbinarySI\u003e        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\u003cdecimalSI\u003e       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\u003cdecimalExponent\u003e ::= \"e\" \u003csignedNumber\u003e | \"E\" \u003csignedNumber\u003e\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+				"type": "string"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup": {
+				"description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+				"type": "object",
+				"required": [
+					"name",
+					"versions"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "name is the name of the group.",
+						"type": "string"
+					},
+					"preferredVersion": {
+						"description": "preferredVersion is the version preferred by the API server, which probably is the storage version.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+							}
+						]
+					},
+					"serverAddressByClientCIDRs": {
+						"description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
+						}
+					},
+					"versions": {
+						"description": "versions are the versions supported in this group.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+						}
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIGroup",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList": {
+				"description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+				"type": "object",
+				"required": [
+					"groups"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"groups": {
+						"description": "groups is a list of APIGroup.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIGroupList",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
+				"description": "APIResource specifies the name of a resource and whether it is namespaced.",
+				"type": "object",
+				"required": [
+					"name",
+					"singularName",
+					"namespaced",
+					"kind",
+					"verbs"
+				],
+				"properties": {
+					"categories": {
+						"description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"group": {
+						"description": "group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale\".",
+						"type": "string"
+					},
+					"kind": {
+						"description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+						"type": "string"
+					},
+					"name": {
+						"description": "name is the plural name of the resource.",
+						"type": "string"
+					},
+					"namespaced": {
+						"description": "namespaced indicates if a resource is namespaced or not.",
+						"type": "boolean"
+					},
+					"shortNames": {
+						"description": "shortNames is a list of suggested short names of the resource.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"singularName": {
+						"description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
+						"type": "string"
+					},
+					"storageVersionHash": {
+						"description": "The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.",
+						"type": "string"
+					},
+					"verbs": {
+						"description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"version": {
+						"description": "version is the preferred version of the resource.  Empty implies the version of the containing resource list For subresources, this may have a different value, for example: v1 (while inside a v1beta1 version of the core resource's group)\".",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+				"description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+				"type": "object",
+				"required": [
+					"groupVersion",
+					"resources"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"groupVersion": {
+						"description": "groupVersion is the group and version this APIResourceList is for.",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"resources": {
+						"description": "resources contains the name of the resources and if they are namespaced.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
+						}
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIResourceList",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+				"description": "DeleteOptions may be provided when deleting an API object.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"dryRun": {
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"gracePeriodSeconds": {
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"orphanDependents": {
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"type": "boolean"
+					},
+					"preconditions": {
+						"description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+							}
+						]
+					},
+					"propagationPolicy": {
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "DeleteOptions",
+						"version": "v1"
+					},
+					{
+						"group": "autoscaling",
+						"kind": "DeleteOptions",
+						"version": "v1"
+					},
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+				"description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
+				"description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+				"type": "object",
+				"required": [
+					"groupVersion",
+					"version"
+				],
+				"properties": {
+					"groupVersion": {
+						"description": "groupVersion specifies the API group and version in the form \"group/version\"",
+						"type": "string"
+					},
+					"version": {
+						"description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+				"description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+				"type": "object",
+				"properties": {
+					"matchExpressions": {
+						"description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+						}
+					},
+					"matchLabels": {
+						"description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+				"description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+				"type": "object",
+				"required": [
+					"key",
+					"operator"
+				],
+				"properties": {
+					"key": {
+						"description": "key is the label key that the selector applies to.",
+						"type": "string",
+						"x-kubernetes-patch-merge-key": "key",
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"operator": {
+						"description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+						"type": "string"
+					},
+					"values": {
+						"description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+				"description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+				"type": "object",
+				"properties": {
+					"continue": {
+						"description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+						"type": "string"
+					},
+					"remainingItemCount": {
+						"description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"resourceVersion": {
+						"description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+						"type": "string"
+					},
+					"selfLink": {
+						"description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+				"description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+						"type": "string"
+					},
+					"fieldsType": {
+						"description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+						"type": "string"
+					},
+					"fieldsV1": {
+						"description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+							}
+						]
+					},
+					"manager": {
+						"description": "Manager is an identifier of the workflow managing these fields.",
+						"type": "string"
+					},
+					"operation": {
+						"description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+						"type": "string"
+					},
+					"subresource": {
+						"description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+						"type": "string"
+					},
+					"time": {
+						"description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+				"description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+				"type": "object",
+				"properties": {
+					"annotations": {
+						"description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"clusterName": {
+						"description": "Deprecated: ClusterName is a legacy field that was always cleared by the system and never used; it will be removed completely in 1.25.\n\nThe name in the go struct is changed to help clients detect accidental use.",
+						"type": "string"
+					},
+					"creationTimestamp": {
+						"description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"deletionGracePeriodSeconds": {
+						"description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"deletionTimestamp": {
+						"description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"finalizers": {
+						"description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"generateName": {
+						"description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+						"type": "string"
+					},
+					"generation": {
+						"description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"labels": {
+						"description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"managedFields": {
+						"description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+						}
+					},
+					"name": {
+						"description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+						"type": "string"
+					},
+					"namespace": {
+						"description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+						"type": "string"
+					},
+					"ownerReferences": {
+						"description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+						},
+						"x-kubernetes-patch-merge-key": "uid",
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"resourceVersion": {
+						"description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+						"type": "string"
+					},
+					"selfLink": {
+						"description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+				"description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+				"type": "object",
+				"required": [
+					"apiVersion",
+					"kind",
+					"name",
+					"uid"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "API version of the referent.",
+						"type": "string"
+					},
+					"blockOwnerDeletion": {
+						"description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+						"type": "boolean"
+					},
+					"controller": {
+						"description": "If true, this reference points to the managing controller.",
+						"type": "boolean"
+					},
+					"kind": {
+						"description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+				"description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+				"description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+				"type": "object",
+				"properties": {
+					"resourceVersion": {
+						"description": "Specifies the target ResourceVersion",
+						"type": "string"
+					},
+					"uid": {
+						"description": "Specifies the target UID.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR": {
+				"description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+				"type": "object",
+				"required": [
+					"clientCIDR",
+					"serverAddress"
+				],
+				"properties": {
+					"clientCIDR": {
+						"description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+						"type": "string"
+					},
+					"serverAddress": {
+						"description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+				"description": "Status is a return value for calls that don't return other objects.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"code": {
+						"description": "Suggested HTTP return code for this status, 0 if not set.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"details": {
+						"description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
+							}
+						]
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"message": {
+						"description": "A human-readable description of the status of this operation.",
+						"type": "string"
+					},
+					"metadata": {
+						"description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+							}
+						]
+					},
+					"reason": {
+						"description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "Status",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+				"description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+				"type": "object",
+				"properties": {
+					"field": {
+						"description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+						"type": "string"
+					},
+					"message": {
+						"description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+						"type": "string"
+					},
+					"reason": {
+						"description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+				"description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+				"type": "object",
+				"properties": {
+					"causes": {
+						"description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+						}
+					},
+					"group": {
+						"description": "The group attribute of the resource associated with the status StatusReason.",
+						"type": "string"
+					},
+					"kind": {
+						"description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+						"type": "string"
+					},
+					"retryAfterSeconds": {
+						"description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"uid": {
+						"description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+				"description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+				"type": "string",
+				"format": "date-time"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+				"description": "Event represents a single event to a watched resource.",
+				"type": "object",
+				"required": [
+					"type",
+					"object"
+				],
+				"properties": {
+					"object": {
+						"description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
+							}
+						]
+					},
+					"type": {
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "WatchEvent",
+						"version": "v1"
+					},
+					{
+						"group": "autoscaling",
+						"kind": "WatchEvent",
+						"version": "v1"
+					},
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.runtime.RawExtension": {
+				"description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.version.Info": {
+				"description": "Info contains versioning information. how we'll want to distribute that information.",
+				"type": "object",
+				"required": [
+					"major",
+					"minor",
+					"gitVersion",
+					"gitCommit",
+					"gitTreeState",
+					"buildDate",
+					"goVersion",
+					"compiler",
+					"platform"
+				],
+				"properties": {
+					"buildDate": {
+						"type": "string"
+					},
+					"compiler": {
+						"type": "string"
+					},
+					"gitCommit": {
+						"type": "string"
+					},
+					"gitTreeState": {
+						"type": "string"
+					},
+					"gitVersion": {
+						"type": "string"
+					},
+					"goVersion": {
+						"type": "string"
+					},
+					"major": {
+						"type": "string"
+					},
+					"minor": {
+						"type": "string"
+					},
+					"platform": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"securitySchemes": {
+			"BearerToken": {
+				"type": "apiKey",
+				"description": "Bearer Token authentication",
+				"name": "authorization",
+				"in": "header"
+			}
+		}
+	}
+}

--- a/gen/v3/apis__storage.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__storage.api.onmetal.de__v1alpha1_openapi.json
@@ -1,0 +1,20902 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"title": "onmetal-api",
+		"version": "0.1"
+	},
+	"paths": {
+		"/apis/": {
+			"get": {
+				"tags": [
+					"apis"
+				],
+				"description": "get available API versions",
+				"operationId": "getAPIVersions",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getComputeApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getComputeApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machineclasses": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind MachineClass",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a MachineClass",
+				"operationId": "createComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of MachineClass",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionMachineClass",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machineclasses/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified MachineClass",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachineClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified MachineClass",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a MachineClass",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified MachineClass",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachineClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind MachinePool",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a MachinePool",
+				"operationId": "createComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of MachinePool",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionMachinePool",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified MachinePool",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachinePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified MachinePool",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a MachinePool",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified MachinePool",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachinePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machinepools/{name}/status": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified MachinePool",
+				"operationId": "readComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified MachinePool",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified MachinePool",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1MachinePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Machine",
+				"operationId": "listComputeApiOnmetalDeV1alpha1MachineForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Machine",
+				"operationId": "listComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Machine",
+				"operationId": "createComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Machine",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1CollectionNamespacedMachine",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Machine",
+				"operationId": "readComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Machine",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Machine",
+				"operationId": "deleteComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Machine",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}/exec": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "connect GET requests to exec of Machine",
+				"operationId": "connectComputeApiOnmetalDeV1alpha1GetNamespacedMachineExec",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "connect",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineExecOptions",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "connect POST requests to exec of Machine",
+				"operationId": "connectComputeApiOnmetalDeV1alpha1PostNamespacedMachineExec",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "connect",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineExecOptions",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "insecureSkipTLSVerifyBackend",
+					"in": "query",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineExecOptions",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/namespaces/{namespace}/machines/{name}/status": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Machine",
+				"operationId": "readComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Machine",
+				"operationId": "replaceComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Machine",
+				"operationId": "patchComputeApiOnmetalDeV1alpha1NamespacedMachineStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machineclasses": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of MachineClass. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineClassList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machineclasses/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind MachineClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachineClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachineClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machinepools": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of MachinePool. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachinePoolList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machinepools/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind MachinePool. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachinePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "MachinePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the MachinePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Machine. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1MachineListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/machines": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Machine. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1NamespacedMachineList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/compute.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/machines/{name}": {
+			"get": {
+				"tags": [
+					"computeApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Machine. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchComputeApiOnmetalDeV1alpha1NamespacedMachine",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "compute.api.onmetal.de",
+					"kind": "Machine",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Machine",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getIpamApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getIpamApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind PrefixAllocation",
+				"operationId": "listIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a PrefixAllocation",
+				"operationId": "createIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of PrefixAllocation",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1CollectionNamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified PrefixAllocation",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified PrefixAllocation",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a PrefixAllocation",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified PrefixAllocation",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixallocations/{name}/status": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified PrefixAllocation",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified PrefixAllocation",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified PrefixAllocation",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Prefix",
+				"operationId": "listIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Prefix",
+				"operationId": "createIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Prefix",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1CollectionNamespacedPrefix",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Prefix",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Prefix",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Prefix",
+				"operationId": "deleteIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Prefix",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/namespaces/{namespace}/prefixes/{name}/status": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Prefix",
+				"operationId": "readIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Prefix",
+				"operationId": "replaceIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Prefix",
+				"operationId": "patchIpamApiOnmetalDeV1alpha1NamespacedPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind PrefixAllocation",
+				"operationId": "listIpamApiOnmetalDeV1alpha1PrefixAllocationForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Prefix",
+				"operationId": "listIpamApiOnmetalDeV1alpha1PrefixForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocationList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixallocations/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixAllocation",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the PrefixAllocation",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Prefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefixList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/prefixes/{name}": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Prefix. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1NamespacedPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Prefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/prefixallocations": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of PrefixAllocation. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1PrefixAllocationListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "PrefixAllocation",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/ipam.api.onmetal.de/v1alpha1/watch/prefixes": {
+			"get": {
+				"tags": [
+					"ipamApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Prefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchIpamApiOnmetalDeV1alpha1PrefixListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "ipam.api.onmetal.de",
+					"kind": "Prefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getNetworkingApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getNetworkingApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefix",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1AliasPrefixForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefixRouting",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1AliasPrefixRoutingForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefix",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create an AliasPrefix",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of AliasPrefix",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified AliasPrefix",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified AliasPrefix",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete an AliasPrefix",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified AliasPrefix",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixes/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified AliasPrefix",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified AliasPrefix",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified AliasPrefix",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind AliasPrefixRouting",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create an AliasPrefixRouting",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of AliasPrefixRouting",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/aliasprefixroutings/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified AliasPrefixRouting",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified AliasPrefixRouting",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete an AliasPrefixRouting",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified AliasPrefixRouting",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefixRouting",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind NetworkInterface",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a NetworkInterface",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of NetworkInterface",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified NetworkInterface",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified NetworkInterface",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a NetworkInterface",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified NetworkInterface",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networkinterfaces/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified NetworkInterface",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified NetworkInterface",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified NetworkInterface",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Network",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Network",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Network",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedNetwork",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/networks/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Network",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Network",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Network",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Network",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Network",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VirtualIP",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VirtualIP",
+				"operationId": "createNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VirtualIP",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1CollectionNamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VirtualIP",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VirtualIP",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VirtualIP",
+				"operationId": "deleteNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VirtualIP",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/namespaces/{namespace}/virtualips/{name}/status": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified VirtualIP",
+				"operationId": "readNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified VirtualIP",
+				"operationId": "replaceNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified VirtualIP",
+				"operationId": "patchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind NetworkInterface",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NetworkInterfaceForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Network",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1NetworkForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VirtualIP",
+				"operationId": "listNetworkingApiOnmetalDeV1alpha1VirtualIPForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1AliasPrefixListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1AliasPrefixRoutingListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixes": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixes/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind AliasPrefix. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefix",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefix",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefix",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixroutings": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRoutingList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/aliasprefixroutings/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind AliasPrefixRouting. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedAliasPrefixRouting",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "AliasPrefixRouting",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the AliasPrefixRouting",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterfaceList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networkinterfaces/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkInterface",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the NetworkInterface",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Network. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetworkList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/networks/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Network. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedNetwork",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Network",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VirtualIP. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIPList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/virtualips/{name}": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VirtualIP. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NamespacedVirtualIP",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VirtualIP",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/networkinterfaces": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of NetworkInterface. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NetworkInterfaceListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "NetworkInterface",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/networks": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Network. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1NetworkListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "Network",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/networking.api.onmetal.de/v1alpha1/watch/virtualips": {
+			"get": {
+				"tags": [
+					"networkingApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VirtualIP. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchNetworkingApiOnmetalDeV1alpha1VirtualIPListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "networking.api.onmetal.de",
+					"kind": "VirtualIP",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe"
+				],
+				"description": "get information of a group",
+				"operationId": "getStorageApiOnmetalDeAPIGroup",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/vnd.kubernetes.protobuf": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "get available resources",
+				"operationId": "getStorageApiOnmetalDeV1alpha1APIResources",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Volume",
+				"operationId": "listStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a Volume",
+				"operationId": "createStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of Volume",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionNamespacedVolume",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified Volume",
+				"operationId": "readStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified Volume",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a Volume",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified Volume",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/namespaces/{namespace}/volumes/{name}/status": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified Volume",
+				"operationId": "readStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified Volume",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified Volume",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1NamespacedVolumeStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumeclasses": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VolumeClass",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VolumeClass",
+				"operationId": "createStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VolumeClass",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionVolumeClass",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumeclasses/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VolumeClass",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumeClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VolumeClass",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VolumeClass",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VolumeClass",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumeClass",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumeClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind VolumePool",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "allowWatchBookmarks",
+						"in": "query",
+						"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "watch",
+						"in": "query",
+						"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"post": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "create a VolumePool",
+				"operationId": "createStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "post",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete collection of VolumePool",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1CollectionVolumePool",
+				"parameters": [
+					{
+						"name": "continue",
+						"in": "query",
+						"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "labelSelector",
+						"in": "query",
+						"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersion",
+						"in": "query",
+						"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "resourceVersionMatch",
+						"in": "query",
+						"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "timeoutSeconds",
+						"in": "query",
+						"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "deletecollection",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read the specified VolumePool",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace the specified VolumePool",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"delete": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "delete a VolumePool",
+				"operationId": "deleteStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "gracePeriodSeconds",
+						"in": "query",
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"schema": {
+							"type": "integer",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "orphanDependents",
+						"in": "query",
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "propagationPolicy",
+						"in": "query",
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "Accepted",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "delete",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update the specified VolumePool",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumePool",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumepools/{name}/status": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "read status of the specified VolumePool",
+				"operationId": "readStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "get",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"put": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "replace status of the specified VolumePool",
+				"operationId": "replaceStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"*/*": {
+							"schema": {
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "put",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"patch": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "partially update status of the specified VolumePool",
+				"operationId": "patchStorageApiOnmetalDeV1alpha1VolumePoolStatus",
+				"parameters": [
+					{
+						"name": "dryRun",
+						"in": "query",
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "fieldManager",
+						"in": "query",
+						"description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+						"schema": {
+							"type": "string",
+							"uniqueItems": true
+						}
+					},
+					{
+						"name": "force",
+						"in": "query",
+						"description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+						"schema": {
+							"type": "boolean",
+							"uniqueItems": true
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/apply-patch+yaml": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/json-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						},
+						"application/strategic-merge-patch+json": {
+							"schema": {
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "patch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "list or watch objects of kind Volume",
+				"operationId": "listStorageApiOnmetalDeV1alpha1VolumeForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "list",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Volume. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1NamespacedVolumeList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/namespaces/{namespace}/volumes/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind Volume. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1NamespacedVolume",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the Volume",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "namespace",
+					"in": "path",
+					"description": "object name and auth scope, such as for teams and projects",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumeclasses": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VolumeClass. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeClassList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumeclasses/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VolumeClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeClass",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumeClass",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumeClass",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumepools": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of VolumePool. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumePoolList",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumepools/{name}": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch changes to an object of kind VolumePool. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumePool",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watch",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "VolumePool",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "name",
+					"in": "path",
+					"description": "name of the VolumePool",
+					"required": true,
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/apis/storage.api.onmetal.de/v1alpha1/watch/volumes": {
+			"get": {
+				"tags": [
+					"storageApiOnmetalDe_v1alpha1"
+				],
+				"description": "watch individual changes to a list of Volume. deprecated: use the 'watch' parameter with a list operation instead.",
+				"operationId": "watchStorageApiOnmetalDeV1alpha1VolumeListForAllNamespaces",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/json;stream=watch": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							},
+							"application/yaml": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				},
+				"x-kubernetes-action": "watchlist",
+				"x-kubernetes-group-version-kind": {
+					"group": "storage.api.onmetal.de",
+					"kind": "Volume",
+					"version": "v1alpha1"
+				}
+			},
+			"parameters": [
+				{
+					"name": "allowWatchBookmarks",
+					"in": "query",
+					"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "continue",
+					"in": "query",
+					"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "fieldSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "labelSelector",
+					"in": "query",
+					"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "limit",
+					"in": "query",
+					"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "pretty",
+					"in": "query",
+					"description": "If 'true', then the output is pretty printed.",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersion",
+					"in": "query",
+					"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "resourceVersionMatch",
+					"in": "query",
+					"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+					"schema": {
+						"type": "string",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "timeoutSeconds",
+					"in": "query",
+					"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+					"schema": {
+						"type": "integer",
+						"uniqueItems": true
+					}
+				},
+				{
+					"name": "watch",
+					"in": "query",
+					"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+					"schema": {
+						"type": "boolean",
+						"uniqueItems": true
+					}
+				}
+			]
+		},
+		"/version/": {
+			"get": {
+				"tags": [
+					"version"
+				],
+				"description": "get the code version",
+				"operationId": "getCodeVersion",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.version.Info"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP": {
+				"description": "IP is an IP address.",
+				"type": "string",
+				"format": "ip"
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix": {
+				"description": "IPPrefix represents a network prefix.",
+				"type": "string",
+				"format": "ip-prefix"
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference": {
+				"description": "LocalUIDReference is a reference to another entity including its UID",
+				"type": "object",
+				"required": [
+					"name",
+					"uid"
+				],
+				"properties": {
+					"name": {
+						"description": "Name is the name of the referenced entity.",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID is the UID of the referenced entity.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.SecretKeySelector": {
+				"description": "SecretKeySelector is a reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
+				"type": "object",
+				"properties": {
+					"key": {
+						"description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+						"type": "string"
+					},
+					"name": {
+						"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint": {
+				"description": "The resource pool this Taint is attached to has the \"effect\" on any resource that does not tolerate the Taint.",
+				"type": "object",
+				"required": [
+					"key",
+					"effect"
+				],
+				"properties": {
+					"effect": {
+						"description": "The effect of the taint on resources that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+						"type": "string"
+					},
+					"key": {
+						"description": "The taint key to be applied to a resource pool.",
+						"type": "string"
+					},
+					"value": {
+						"description": "The taint value corresponding to the taint key.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration": {
+				"description": "The resource this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+				"type": "object",
+				"properties": {
+					"effect": {
+						"description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule.",
+						"type": "string"
+					},
+					"key": {
+						"description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+						"type": "string"
+					},
+					"operator": {
+						"description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a resource can tolerate all taints of a particular category.",
+						"type": "string"
+					},
+					"value": {
+						"description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.DaemonEndpoint": {
+				"description": "DaemonEndpoint contains information about a single Daemon endpoint.",
+				"type": "object",
+				"required": [
+					"port"
+				],
+				"properties": {
+					"port": {
+						"description": "Port number of the given endpoint.",
+						"type": "integer",
+						"format": "int32"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EFIVar": {
+				"description": "EFIVar is a variable to pass to EFI while booting up.",
+				"type": "object",
+				"required": [
+					"name",
+					"uuid",
+					"value"
+				],
+				"properties": {
+					"name": {
+						"description": "Name is the name of the EFIVar.",
+						"type": "string"
+					},
+					"uuid": {
+						"description": "UUID is the uuid of the EFIVar.",
+						"type": "string"
+					},
+					"value": {
+						"description": "Value is the value of the EFIVar.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EmptyDiskVolumeSource": {
+				"description": "EmptyDiskVolumeSource is a volume that's offered by the machine pool provider. Usually ephemeral (i.e. deleted when the surrounding entity is deleted), with varying performance characteristics. Potentially not recoverable.",
+				"type": "object",
+				"properties": {
+					"sizeLimit": {
+						"description": "SizeLimit is the total amount of local storage required for this EmptyDisk volume. The default is nil which means that the limit is undefined.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralNetworkInterfaceSource": {
+				"description": "EphemeralNetworkInterfaceSource is a definition for an ephemeral (i.e. coupled to the lifetime of the surrounding object) networking.NetworkInterface.",
+				"type": "object",
+				"properties": {
+					"networkInterfaceTemplate": {
+						"description": "NetworkInterfaceTemplate is the template definition of the networking.NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralVolumeSource": {
+				"description": "EphemeralVolumeSource is a definition for an ephemeral (i.e. coupled to the lifetime of the surrounding object) storage.Volume.",
+				"type": "object",
+				"properties": {
+					"volumeTemplate": {
+						"description": "VolumeTemplate is the template definition of the storage.Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine": {
+				"description": "Machine is the Schema for the machines API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "Machine",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass": {
+				"description": "MachineClass is the Schema for the machineclasses API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"capabilities": {
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineClass",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClassList": {
+				"description": "MachineClassList contains a list of MachineClass",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineClass"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineClassList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineCondition": {
+				"description": "MachineCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineList": {
+				"description": "MachineList contains a list of Machine",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Machine"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachineList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool": {
+				"description": "MachinePool is the Schema for the machinepools API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachinePool",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolAddress": {
+				"type": "object",
+				"required": [
+					"type",
+					"address"
+				],
+				"properties": {
+					"address": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolCondition": {
+				"description": "MachinePoolCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status",
+					"reason",
+					"message"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolDaemonEndpoints": {
+				"description": "MachinePoolDaemonEndpoints lists ports opened by daemons running on the MachinePool.",
+				"type": "object",
+				"properties": {
+					"machinepoolletEndpoint": {
+						"description": "Endpoint on which machinepoollet is listening.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.DaemonEndpoint"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolList": {
+				"description": "MachinePoolList contains a list of MachinePool",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePool"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "MachinePoolList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolSpec": {
+				"description": "MachinePoolSpec defines the desired state of MachinePool",
+				"type": "object",
+				"required": [
+					"providerID"
+				],
+				"properties": {
+					"providerID": {
+						"description": "ProviderID identifies the MachinePool on provider side.",
+						"type": "string"
+					},
+					"taints": {
+						"description": "Taints of the MachinePool. Only Machines who tolerate all the taints will land in the MachinePool.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolStatus": {
+				"description": "MachinePoolStatus defines the observed state of MachinePool",
+				"type": "object",
+				"properties": {
+					"addresses": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolAddress"
+						}
+					},
+					"availableMachineClasses": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+						}
+					},
+					"conditions": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolCondition"
+						}
+					},
+					"daemonEndpoints": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachinePoolDaemonEndpoints"
+					},
+					"state": {
+						"description": "Possible enum values:\n - `\"Error\"` marks a MachinePool in an error state.\n - `\"Offline\"` marks a MachinePool as offline.\n - `\"Pending\"` marks a MachinePool as pending readiness.\n - `\"Ready\"` marks a MachinePool as ready for accepting a Machine.",
+						"type": "string",
+						"enum": [
+							"Error",
+							"Offline",
+							"Pending",
+							"Ready"
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineSpec": {
+				"description": "MachineSpec defines the desired state of Machine",
+				"type": "object",
+				"required": [
+					"machineClassRef",
+					"image"
+				],
+				"properties": {
+					"efiVars": {
+						"description": "EFIVars are variables to pass to EFI while booting up.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EFIVar"
+						}
+					},
+					"ignitionRef": {
+						"description": "IgnitionRef is a reference to a config map containing the ignition YAML for the machine to boot up. If key is empty, DefaultIgnitionKey will be used as fallback.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.SecretKeySelector"
+							}
+						]
+					},
+					"image": {
+						"description": "Image is the URL providing the operating system image of the machine.",
+						"type": "string"
+					},
+					"imagePullSecret": {
+						"description": "ImagePullSecretRef is an optional secret for pulling the image of a machine.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machineClassRef": {
+						"description": "MachineClassRef is a reference to the machine class/flavor of the machine.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machinePoolRef": {
+						"description": "MachinePoolRef defines machine pool to run the machine in. If empty, a scheduler will figure out an appropriate pool to run the machine in.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"machinePoolSelector": {
+						"description": "MachinePoolSelector selects a suitable MachinePoolRef by the given labels.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"networkInterfaces": {
+						"description": "NetworkInterfaces define a list of network interfaces present on the machine",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterface"
+						}
+					},
+					"tolerations": {
+						"description": "Tolerations define tolerations the Machine has. Only MachinePools whose taints covered by Tolerations will be considered to run the Machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration"
+						}
+					},
+					"volumes": {
+						"description": "Volumes are volumes attached to this machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Volume"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineStatus": {
+				"description": "MachineStatus defines the observed state of Machine",
+				"type": "object",
+				"properties": {
+					"conditions": {
+						"description": "Conditions are the conditions of the machines.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.MachineCondition"
+						}
+					},
+					"networkInterfaces": {
+						"description": "NetworkInterfaces is the list of network interface states for the machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterfaceStatus"
+						}
+					},
+					"state": {
+						"description": "State is the state of the machine.\n\nPossible enum values:\n - `\"Error\"` means the machine is in an error state.\n - `\"Pending\"` means the Machine has been accepted by the system, but not yet completely started. This includes time before being bound to a MachinePool, as well as time spent setting up the Machine on that MachinePool.\n - `\"Running\"` means the machine is running on a MachinePool.\n - `\"Shutdown\"` means the machine is shut down.",
+						"type": "string",
+						"enum": [
+							"Error",
+							"Pending",
+							"Running",
+							"Shutdown"
+						]
+					},
+					"volumes": {
+						"description": "Volumes is the list of volume states for the machine.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.VolumeStatus"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterface": {
+				"description": "NetworkInterface is the definition of a single interface",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) NetworkInterface to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralNetworkInterfaceSource"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the network interface.",
+						"type": "string"
+					},
+					"networkInterfaceRef": {
+						"description": "NetworkInterfaceRef instructs to use the NetworkInterface at the target reference.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.NetworkInterfaceStatus": {
+				"description": "NetworkInterfaceStatus reports the status of an NetworkInterfaceSource.",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"ips": {
+						"description": "IPs are the ips allocated for the network interface.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+						}
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the NetworkInterface to whom the status belongs to.",
+						"type": "string"
+					},
+					"phase": {
+						"description": "Phase is the NetworkInterface binding phase of the NetworkInterface.",
+						"type": "string"
+					},
+					"virtualIP": {
+						"description": "VirtualIP is the virtual ip allocated for the network interface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.Volume": {
+				"description": "Volume defines a volume attachment of a machine",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"device": {
+						"description": "Device is the device name where the volume should be attached. If empty, an unused device name will be determined if possible.",
+						"type": "string"
+					},
+					"emptyDisk": {
+						"description": "EmptyDisk instructs to use a Volume offered by the machine pool provider.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EmptyDiskVolumeSource"
+							}
+						]
+					},
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) Volume to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.compute.v1alpha1.EphemeralVolumeSource"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of the Volume",
+						"type": "string"
+					},
+					"volumeRef": {
+						"description": "VolumeRef instructs to use the specified Volume as source for the attachment.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.compute.v1alpha1.VolumeStatus": {
+				"description": "VolumeStatus is the status of a Volume.",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"deviceID": {
+						"description": "DeviceID is the disk device ID on the host.",
+						"type": "string"
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"name": {
+						"description": "Name is the name of a volume attachment.",
+						"type": "string"
+					},
+					"phase": {
+						"description": "Phase represents the binding phase of a Volume.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix": {
+				"description": "Prefix is the Schema for the prefixes API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "Prefix",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation": {
+				"description": "PrefixAllocation is the Schema for the prefixallocations API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixAllocation",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationList": {
+				"description": "PrefixAllocationList contains a list of PrefixAllocation",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocation"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixAllocationList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationSpec": {
+				"description": "PrefixAllocationSpec defines the desired state of PrefixAllocation",
+				"type": "object",
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the IPFamily of the prefix. If unset but Prefix is set, this can be inferred.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the prefix to allocate for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					},
+					"prefixLength": {
+						"description": "PrefixLength is the length of prefix to allocate for this Prefix.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"prefixRef": {
+						"description": "PrefixRef references the prefix to allocate from.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"prefixSelector": {
+						"description": "PrefixSelector selects the prefix to allocate from.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixAllocationStatus": {
+				"description": "PrefixAllocationStatus is the status of a PrefixAllocation.",
+				"type": "object",
+				"properties": {
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase changed values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the phase of the PrefixAllocation.",
+						"type": "string"
+					},
+					"prefix": {
+						"description": "Prefix is the allocated prefix, if any",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixList": {
+				"description": "PrefixList contains a list of Prefix",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.Prefix"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "PrefixList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec": {
+				"description": "PrefixSpec defines the desired state of Prefix",
+				"type": "object",
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the IPFamily of the prefix. If unset but Prefix is set, this can be inferred.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"parentRef": {
+						"description": "ParentRef references the parent to allocate the Prefix from. If ParentRef and ParentSelector is empty, the Prefix is considered a root prefix and thus allocated by itself.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"parentSelector": {
+						"description": "ParentSelector is the LabelSelector to use for determining the parent for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the prefix to allocate for this Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					},
+					"prefixLength": {
+						"description": "PrefixLength is the length of prefix to allocate for this Prefix.",
+						"type": "integer",
+						"format": "int32"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixStatus": {
+				"description": "PrefixStatus defines the observed state of Prefix",
+				"type": "object",
+				"properties": {
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase changed values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the PrefixPhase of the Prefix.",
+						"type": "string"
+					},
+					"used": {
+						"description": "Used is a list of used prefixes.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixTemplateSpec": {
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix": {
+				"description": "AliasPrefix is the Schema for the AliasPrefix API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefix",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixList": {
+				"description": "AliasPrefixList contains a list of AliasPrefix",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefix"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting": {
+				"description": "AliasPrefixRouting is the Schema for the aliasprefixrouting API",
+				"type": "object",
+				"required": [
+					"destinations"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"destinations": {
+						"description": "Destinations are the destinations for an AliasPrefix.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixRouting",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRoutingList": {
+				"description": "AliasPrefixRoutingList contains a list of AliasPrefixRouting",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixRouting"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "AliasPrefixRoutingList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixSpec": {
+				"description": "AliasPrefixSpec defines the desired state of AliasPrefix",
+				"type": "object",
+				"required": [
+					"networkRef"
+				],
+				"properties": {
+					"networkInterfaceSelector": {
+						"description": "NetworkInterfaceSelector defines the NetworkInterfaces for which this AliasPrefix should be applied",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+							}
+						]
+					},
+					"networkRef": {
+						"description": "NetworkRef is the Network this AliasPrefix should belong to",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"prefix": {
+						"description": "Prefix is the provided Prefix or Ephemeral which should be used by this AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.PrefixSource"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.AliasPrefixStatus": {
+				"description": "AliasPrefixStatus defines the observed state of AliasPrefix",
+				"type": "object",
+				"properties": {
+					"prefix": {
+						"description": "Prefix is the Prefix reserved by this AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource": {
+				"description": "EphemeralPrefixSource contains the definition to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) Prefix.",
+				"type": "object",
+				"properties": {
+					"prefixTemplate": {
+						"description": "PrefixTemplate is the template for the Prefix.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.ipam.v1alpha1.PrefixTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralVirtualIPSource": {
+				"description": "EphemeralVirtualIPSource contains the definition to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) VirtualIP.",
+				"type": "object",
+				"properties": {
+					"virtualIPTemplate": {
+						"description": "VirtualIPTemplate is the template for the VirtualIP.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPTemplateSpec"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.IPSource": {
+				"description": "IPSource is the definition of how to obtain an IP.",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral specifies an IP by creating an ephemeral Prefix to allocate the IP with.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource"
+							}
+						]
+					},
+					"value": {
+						"description": "Value specifies an IP by using an IP literal.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network": {
+				"description": "Network is the Schema for the network API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "Network",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface": {
+				"description": "NetworkInterface is the Schema for the networkinterfaces API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkInterface",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceList": {
+				"description": "NetworkInterfaceList contains a list of NetworkInterface",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterface"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkInterfaceList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec": {
+				"description": "NetworkInterfaceSpec defines the desired state of NetworkInterface",
+				"type": "object",
+				"required": [
+					"networkRef",
+					"ipFamilies",
+					"ips"
+				],
+				"properties": {
+					"ipFamilies": {
+						"description": "IPFamilies defines which IPFamilies this NetworkInterface is supporting",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"ips": {
+						"description": "IPs is the list of provided IPs or EphemeralIPs which should be assigned to this NetworkInterface",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.IPSource"
+						}
+					},
+					"machineRef": {
+						"description": "MachineRef is the Machine this NetworkInterface is used by",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"networkRef": {
+						"description": "NetworkRef is the Network this NetworkInterface is connected to",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"virtualIP": {
+						"description": "VirtualIP specifies the virtual ip that should be assigned to this NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSource"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceStatus": {
+				"description": "NetworkInterfaceStatus defines the observed state of NetworkInterface",
+				"type": "object",
+				"properties": {
+					"ips": {
+						"description": "IPs represent the effective IP addresses of the NetworkInterface",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+						}
+					},
+					"phase": {
+						"description": "Phase is the NetworkInterfacePhase of the NetworkInterface.",
+						"type": "string"
+					},
+					"phaseLastTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned from one value to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"virtualIP": {
+						"description": "VirtualIP is any virtual ip assigned to the NetworkInterface.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceTemplateSpec": {
+				"description": "NetworkInterfaceTemplateSpec is the specification of a NetworkInterface template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkInterfaceSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.NetworkList": {
+				"description": "NetworkList contains a list of Network",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.Network"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "NetworkList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.PrefixSource": {
+				"description": "PrefixSource is the source of the Prefix definition in an AliasPrefix",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral defines the Prefix which should be allocated by the AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralPrefixSource"
+							}
+						]
+					},
+					"value": {
+						"description": "Value is a single IPPrefix value as defined in the AliasPrefix",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IPPrefix"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP": {
+				"description": "VirtualIP is the Schema for the virtualips API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "VirtualIP",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPList": {
+				"description": "VirtualIPList contains a list of VirtualIP",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIP"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "VirtualIPList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSource": {
+				"description": "VirtualIPSource is the definition of how to obtain a VirtualIP.",
+				"type": "object",
+				"properties": {
+					"ephemeral": {
+						"description": "Ephemeral instructs to create an ephemeral (i.e. coupled to the lifetime of the surrounding object) VirtualIP.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.EphemeralVirtualIPSource"
+							}
+						]
+					},
+					"virtualIPRef": {
+						"description": "VirtualIPRef references a VirtualIP to use.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec": {
+				"description": "VirtualIPSpec defines the desired state of VirtualIP",
+				"type": "object",
+				"required": [
+					"type",
+					"ipFamily"
+				],
+				"properties": {
+					"ipFamily": {
+						"description": "IPFamily is the ip family of the VirtualIP.\n\nPossible enum values:\n - `\"IPv4\"` indicates that this IP is IPv4 protocol\n - `\"IPv6\"` indicates that this IP is IPv6 protocol",
+						"type": "string",
+						"enum": [
+							"IPv4",
+							"IPv6"
+						]
+					},
+					"targetRef": {
+						"description": "TargetRef references the target for this VirtualIP (currently only NetworkInterface).",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"type": {
+						"description": "Type is the type of VirtualIP.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPStatus": {
+				"description": "VirtualIPStatus defines the observed state of VirtualIP",
+				"type": "object",
+				"properties": {
+					"ip": {
+						"description": "IP is the allocated IP, if any.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.IP"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase is the VirtualIPPhase of the VirtualIP.",
+						"type": "string"
+					},
+					"phaseLastTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned from one value to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPTemplateSpec": {
+				"description": "VirtualIPTemplateSpec is the specification of a VirtualIP template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.networking.v1alpha1.VirtualIPSpec"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume": {
+				"description": "Volume is the Schema for the volumes API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "Volume",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeAccess": {
+				"description": "VolumeAccess represents information on how to access a volume.",
+				"type": "object",
+				"required": [
+					"driver"
+				],
+				"properties": {
+					"driver": {
+						"description": "Driver is the name of the drive to use for this volume. Required.",
+						"type": "string"
+					},
+					"secretRef": {
+						"description": "SecretRef references the Secret containing the access credentials to consume a Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumeAttributes": {
+						"description": "VolumeAttributes are attributes of the volume to use.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass": {
+				"description": "VolumeClass is the Schema for the volumeclasses API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"capabilities": {
+						"description": "Capabilities describes the capabilities of a VolumeClass.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeClass",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClassList": {
+				"description": "VolumeClassList contains a list of VolumeClass",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeClass"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeClassList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeCondition": {
+				"description": "VolumeCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeList": {
+				"description": "VolumeList contains a list of Volume",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.Volume"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumeList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool": {
+				"description": "VolumePool is the Schema for the volumepools API",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolSpec"
+					},
+					"status": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolStatus"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumePool",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolCondition": {
+				"description": "VolumePoolCondition is one of the conditions of a volume.",
+				"type": "object",
+				"required": [
+					"type",
+					"status",
+					"reason",
+					"message"
+				],
+				"properties": {
+					"lastTransitionTime": {
+						"description": "LastTransitionTime is the last time the status of a condition has transitioned from one state to another.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"message": {
+						"description": "Message is a human-readable explanation of why the condition has a certain reason / state.",
+						"type": "string"
+					},
+					"observedGeneration": {
+						"description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"reason": {
+						"description": "Reason is a machine-readable indication of why the condition is in a certain state.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status is the status of the condition.",
+						"type": "string"
+					},
+					"type": {
+						"description": "Type is the type of the condition.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolList": {
+				"description": "VolumePoolList contains a list of VolumePool",
+				"type": "object",
+				"required": [
+					"items"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"items": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePool"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "VolumePoolList",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolSpec": {
+				"description": "VolumePoolSpec defines the desired state of VolumePool",
+				"type": "object",
+				"required": [
+					"providerID"
+				],
+				"properties": {
+					"providerID": {
+						"description": "ProviderID identifies the VolumePool on provider side.",
+						"type": "string"
+					},
+					"taints": {
+						"description": "Taints of the VolumePool. Only Volumes who tolerate all the taints will land in the VolumePool.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Taint"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolStatus": {
+				"description": "VolumePoolStatus defines the observed state of VolumePool",
+				"type": "object",
+				"properties": {
+					"available": {
+						"description": "Available list the available capacity of a VolumePool.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"availableVolumeClasses": {
+						"description": "AvailableVolumeClasses list the references of any supported VolumeClass of this pool",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+						}
+					},
+					"conditions": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumePoolCondition"
+						}
+					},
+					"state": {
+						"type": "string"
+					},
+					"used": {
+						"description": "Used indicates how much capacity has been used in a VolumePool.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec": {
+				"description": "VolumeSpec defines the desired state of Volume",
+				"type": "object",
+				"required": [
+					"volumeClassRef"
+				],
+				"properties": {
+					"claimRef": {
+						"description": "ClaimRef is the reference to the claiming entity of the Volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.LocalUIDReference"
+							}
+						]
+					},
+					"image": {
+						"description": "Image is an optional image to bootstrap the volume with.",
+						"type": "string"
+					},
+					"imagePullSecretRef": {
+						"description": "ImagePullSecretRef is an optional secret for pulling the image of a volume.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"resources": {
+						"description": "Resources is a description of the volume's resources and capacity.",
+						"type": "object",
+						"additionalProperties": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
+						}
+					},
+					"tolerations": {
+						"description": "Tolerations define tolerations the Volume has. Only any VolumePool whose taints covered by Tolerations will be considered to host the Volume.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.common.v1alpha1.Toleration"
+						}
+					},
+					"unclaimable": {
+						"description": "Unclaimable marks the volume as unclaimable.",
+						"type": "boolean"
+					},
+					"volumeClassRef": {
+						"description": "VolumeClassRef is the VolumeClass of a volume",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumePoolRef": {
+						"description": "VolumePoolRef indicates which VolumePool to use for a volume. If unset, the scheduler will figure out a suitable VolumePoolRef.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
+					"volumePoolSelector": {
+						"description": "VolumePoolSelector selects a suitable VolumePoolRef by the given labels.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeStatus": {
+				"description": "VolumeStatus defines the observed state of Volume",
+				"type": "object",
+				"properties": {
+					"access": {
+						"description": "Access specifies how to access a Volume. This is set by the volume provider when the volume is provisioned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeAccess"
+							}
+						]
+					},
+					"conditions": {
+						"description": "Conditions are the conditions of a volume.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeCondition"
+						}
+					},
+					"lastPhaseTransitionTime": {
+						"description": "LastPhaseTransitionTime is the last time the Phase transitioned between values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"lastStateTransitionTime": {
+						"description": "LastStateTransitionTime is the last time the State transitioned between values.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"phase": {
+						"description": "Phase represents the binding phase of a Volume.",
+						"type": "string"
+					},
+					"state": {
+						"description": "State represents the infrastructure state of a Volume.",
+						"type": "string"
+					}
+				}
+			},
+			"com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeTemplateSpec": {
+				"description": "VolumeTemplateSpec is the specification of a Volume template.",
+				"type": "object",
+				"properties": {
+					"metadata": {
+						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"spec": {
+						"$ref": "#/components/schemas/com.github.onmetal.onmetal-api.apis.storage.v1alpha1.VolumeSpec"
+					}
+				}
+			},
+			"io.k8s.api.core.v1.LocalObjectReference": {
+				"description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+				"type": "object",
+				"properties": {
+					"name": {
+						"description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.api.resource.Quantity": {
+				"description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n\u003cquantity\u003e        ::= \u003csignedNumber\u003e\u003csuffix\u003e\n  (Note that \u003csuffix\u003e may be empty, from the \"\" case in \u003cdecimalSI\u003e.)\n\u003cdigit\u003e           ::= 0 | 1 | ... | 9 \u003cdigits\u003e          ::= \u003cdigit\u003e | \u003cdigit\u003e\u003cdigits\u003e \u003cnumber\u003e          ::= \u003cdigits\u003e | \u003cdigits\u003e.\u003cdigits\u003e | \u003cdigits\u003e. | .\u003cdigits\u003e \u003csign\u003e            ::= \"+\" | \"-\" \u003csignedNumber\u003e    ::= \u003cnumber\u003e | \u003csign\u003e\u003cnumber\u003e \u003csuffix\u003e          ::= \u003cbinarySI\u003e | \u003cdecimalExponent\u003e | \u003cdecimalSI\u003e \u003cbinarySI\u003e        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\u003cdecimalSI\u003e       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\u003cdecimalExponent\u003e ::= \"e\" \u003csignedNumber\u003e | \"E\" \u003csignedNumber\u003e\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+				"type": "string"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup": {
+				"description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+				"type": "object",
+				"required": [
+					"name",
+					"versions"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "name is the name of the group.",
+						"type": "string"
+					},
+					"preferredVersion": {
+						"description": "preferredVersion is the version preferred by the API server, which probably is the storage version.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+							}
+						]
+					},
+					"serverAddressByClientCIDRs": {
+						"description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
+						}
+					},
+					"versions": {
+						"description": "versions are the versions supported in this group.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+						}
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIGroup",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList": {
+				"description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+				"type": "object",
+				"required": [
+					"groups"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"groups": {
+						"description": "groups is a list of APIGroup.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+						}
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIGroupList",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
+				"description": "APIResource specifies the name of a resource and whether it is namespaced.",
+				"type": "object",
+				"required": [
+					"name",
+					"singularName",
+					"namespaced",
+					"kind",
+					"verbs"
+				],
+				"properties": {
+					"categories": {
+						"description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"group": {
+						"description": "group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale\".",
+						"type": "string"
+					},
+					"kind": {
+						"description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+						"type": "string"
+					},
+					"name": {
+						"description": "name is the plural name of the resource.",
+						"type": "string"
+					},
+					"namespaced": {
+						"description": "namespaced indicates if a resource is namespaced or not.",
+						"type": "boolean"
+					},
+					"shortNames": {
+						"description": "shortNames is a list of suggested short names of the resource.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"singularName": {
+						"description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
+						"type": "string"
+					},
+					"storageVersionHash": {
+						"description": "The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.",
+						"type": "string"
+					},
+					"verbs": {
+						"description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"version": {
+						"description": "version is the preferred version of the resource.  Empty implies the version of the containing resource list For subresources, this may have a different value, for example: v1 (while inside a v1beta1 version of the core resource's group)\".",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+				"description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+				"type": "object",
+				"required": [
+					"groupVersion",
+					"resources"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"groupVersion": {
+						"description": "groupVersion is the group and version this APIResourceList is for.",
+						"type": "string"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"resources": {
+						"description": "resources contains the name of the resources and if they are namespaced.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
+						}
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "APIResourceList",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+				"description": "DeleteOptions may be provided when deleting an API object.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"dryRun": {
+						"description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"gracePeriodSeconds": {
+						"description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"orphanDependents": {
+						"description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+						"type": "boolean"
+					},
+					"preconditions": {
+						"description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+							}
+						]
+					},
+					"propagationPolicy": {
+						"description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "DeleteOptions",
+						"version": "v1"
+					},
+					{
+						"group": "autoscaling",
+						"kind": "DeleteOptions",
+						"version": "v1"
+					},
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "DeleteOptions",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+				"description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
+				"description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+				"type": "object",
+				"required": [
+					"groupVersion",
+					"version"
+				],
+				"properties": {
+					"groupVersion": {
+						"description": "groupVersion specifies the API group and version in the form \"group/version\"",
+						"type": "string"
+					},
+					"version": {
+						"description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+				"description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+				"type": "object",
+				"properties": {
+					"matchExpressions": {
+						"description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+						}
+					},
+					"matchLabels": {
+						"description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+				"description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+				"type": "object",
+				"required": [
+					"key",
+					"operator"
+				],
+				"properties": {
+					"key": {
+						"description": "key is the label key that the selector applies to.",
+						"type": "string",
+						"x-kubernetes-patch-merge-key": "key",
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"operator": {
+						"description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+						"type": "string"
+					},
+					"values": {
+						"description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+				"description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+				"type": "object",
+				"properties": {
+					"continue": {
+						"description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+						"type": "string"
+					},
+					"remainingItemCount": {
+						"description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"resourceVersion": {
+						"description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+						"type": "string"
+					},
+					"selfLink": {
+						"description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+				"description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+						"type": "string"
+					},
+					"fieldsType": {
+						"description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+						"type": "string"
+					},
+					"fieldsV1": {
+						"description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+							}
+						]
+					},
+					"manager": {
+						"description": "Manager is an identifier of the workflow managing these fields.",
+						"type": "string"
+					},
+					"operation": {
+						"description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+						"type": "string"
+					},
+					"subresource": {
+						"description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+						"type": "string"
+					},
+					"time": {
+						"description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+				"description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+				"type": "object",
+				"properties": {
+					"annotations": {
+						"description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"clusterName": {
+						"description": "Deprecated: ClusterName is a legacy field that was always cleared by the system and never used; it will be removed completely in 1.25.\n\nThe name in the go struct is changed to help clients detect accidental use.",
+						"type": "string"
+					},
+					"creationTimestamp": {
+						"description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"deletionGracePeriodSeconds": {
+						"description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"deletionTimestamp": {
+						"description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+							}
+						]
+					},
+					"finalizers": {
+						"description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"generateName": {
+						"description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+						"type": "string"
+					},
+					"generation": {
+						"description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+						"type": "integer",
+						"format": "int64"
+					},
+					"labels": {
+						"description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+						"type": "object",
+						"additionalProperties": {
+							"type": "string"
+						}
+					},
+					"managedFields": {
+						"description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+						}
+					},
+					"name": {
+						"description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+						"type": "string"
+					},
+					"namespace": {
+						"description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+						"type": "string"
+					},
+					"ownerReferences": {
+						"description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+						},
+						"x-kubernetes-patch-merge-key": "uid",
+						"x-kubernetes-patch-strategy": "merge"
+					},
+					"resourceVersion": {
+						"description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+						"type": "string"
+					},
+					"selfLink": {
+						"description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+				"description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+				"type": "object",
+				"required": [
+					"apiVersion",
+					"kind",
+					"name",
+					"uid"
+				],
+				"properties": {
+					"apiVersion": {
+						"description": "API version of the referent.",
+						"type": "string"
+					},
+					"blockOwnerDeletion": {
+						"description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+						"type": "boolean"
+					},
+					"controller": {
+						"description": "If true, this reference points to the managing controller.",
+						"type": "boolean"
+					},
+					"kind": {
+						"description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+						"type": "string"
+					},
+					"uid": {
+						"description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-map-type": "atomic"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+				"description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+				"description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+				"type": "object",
+				"properties": {
+					"resourceVersion": {
+						"description": "Specifies the target ResourceVersion",
+						"type": "string"
+					},
+					"uid": {
+						"description": "Specifies the target UID.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR": {
+				"description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+				"type": "object",
+				"required": [
+					"clientCIDR",
+					"serverAddress"
+				],
+				"properties": {
+					"clientCIDR": {
+						"description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+						"type": "string"
+					},
+					"serverAddress": {
+						"description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+				"description": "Status is a return value for calls that don't return other objects.",
+				"type": "object",
+				"properties": {
+					"apiVersion": {
+						"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+						"type": "string"
+					},
+					"code": {
+						"description": "Suggested HTTP return code for this status, 0 if not set.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"details": {
+						"description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
+							}
+						]
+					},
+					"kind": {
+						"description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"message": {
+						"description": "A human-readable description of the status of this operation.",
+						"type": "string"
+					},
+					"metadata": {
+						"description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+							}
+						]
+					},
+					"reason": {
+						"description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+						"type": "string"
+					},
+					"status": {
+						"description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "Status",
+						"version": "v1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+				"description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+				"type": "object",
+				"properties": {
+					"field": {
+						"description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+						"type": "string"
+					},
+					"message": {
+						"description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+						"type": "string"
+					},
+					"reason": {
+						"description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+				"description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+				"type": "object",
+				"properties": {
+					"causes": {
+						"description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+						}
+					},
+					"group": {
+						"description": "The group attribute of the resource associated with the status StatusReason.",
+						"type": "string"
+					},
+					"kind": {
+						"description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+						"type": "string"
+					},
+					"name": {
+						"description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+						"type": "string"
+					},
+					"retryAfterSeconds": {
+						"description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+						"type": "integer",
+						"format": "int32"
+					},
+					"uid": {
+						"description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+						"type": "string"
+					}
+				}
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+				"description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+				"type": "string",
+				"format": "date-time"
+			},
+			"io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+				"description": "Event represents a single event to a watched resource.",
+				"type": "object",
+				"required": [
+					"type",
+					"object"
+				],
+				"properties": {
+					"object": {
+						"description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.runtime.RawExtension"
+							}
+						]
+					},
+					"type": {
+						"type": "string"
+					}
+				},
+				"x-kubernetes-group-version-kind": [
+					{
+						"group": "",
+						"kind": "WatchEvent",
+						"version": "v1"
+					},
+					{
+						"group": "autoscaling",
+						"kind": "WatchEvent",
+						"version": "v1"
+					},
+					{
+						"group": "compute.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "ipam.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "networking.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					},
+					{
+						"group": "storage.api.onmetal.de",
+						"kind": "WatchEvent",
+						"version": "v1alpha1"
+					}
+				]
+			},
+			"io.k8s.apimachinery.pkg.runtime.RawExtension": {
+				"description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+				"type": "object"
+			},
+			"io.k8s.apimachinery.pkg.version.Info": {
+				"description": "Info contains versioning information. how we'll want to distribute that information.",
+				"type": "object",
+				"required": [
+					"major",
+					"minor",
+					"gitVersion",
+					"gitCommit",
+					"gitTreeState",
+					"buildDate",
+					"goVersion",
+					"compiler",
+					"platform"
+				],
+				"properties": {
+					"buildDate": {
+						"type": "string"
+					},
+					"compiler": {
+						"type": "string"
+					},
+					"gitCommit": {
+						"type": "string"
+					},
+					"gitTreeState": {
+						"type": "string"
+					},
+					"gitVersion": {
+						"type": "string"
+					},
+					"goVersion": {
+						"type": "string"
+					},
+					"major": {
+						"type": "string"
+					},
+					"minor": {
+						"type": "string"
+					},
+					"platform": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"securitySchemes": {
+			"BearerToken": {
+				"type": "apiKey",
+				"description": "Bearer Token authentication",
+				"name": "authorization",
+				"in": "header"
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
+	github.com/bits-and-blooms/bitset v1.3.3
 	github.com/go-logr/logr v1.2.3
 	github.com/golang/mock v1.6.0
 	github.com/google/addlicense v1.0.0
@@ -46,7 +47,6 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bits-and-blooms/bitset v1.3.3 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect


### PR DESCRIPTION
# Proposed Changes

You can now extract the OpenAPI v2 and v3 specification by running
```
make extract-openapi
```
The generated files will be stored in the `./gen` folder.