### PR TITLE
Make `Machine` `image` field optional

### DIFF
--- a/apis/compute/machine_types.go
+++ b/apis/compute/machine_types.go
@@ -33,7 +33,7 @@ type MachineSpec struct {
 	// MachinePoolRef defines machine pool to run the machine in.
 	// If empty, a scheduler will figure out an appropriate pool to run the machine in.
 	MachinePoolRef *corev1.LocalObjectReference
-	// Image is the URL providing the operating system image of the machine.
+	// Image is the optional URL providing the operating system image of the machine.
 	Image string
 	// ImagePullSecretRef is an optional secret for pulling the image of a machine.
 	ImagePullSecretRef *corev1.LocalObjectReference

--- a/apis/compute/v1alpha1/machine_types.go
+++ b/apis/compute/v1alpha1/machine_types.go
@@ -33,8 +33,9 @@ type MachineSpec struct {
 	// MachinePoolRef defines machine pool to run the machine in.
 	// If empty, a scheduler will figure out an appropriate pool to run the machine in.
 	MachinePoolRef *corev1.LocalObjectReference `json:"machinePoolRef,omitempty"`
-	// Image is the URL providing the operating system image of the machine.
-	Image string `json:"image"`
+	// Image is the optional URL providing the operating system image of the machine.
+	// +optional
+	Image string `json:"image,omitempty"`
 	// ImagePullSecretRef is an optional secret for pulling the image of a machine.
 	ImagePullSecretRef *corev1.LocalObjectReference `json:"imagePullSecret,omitempty"`
 	// NetworkInterfaces define a list of network interfaces present on the machine

--- a/docs/api-reference/common.md
+++ b/docs/api-reference/common.md
@@ -76,7 +76,9 @@ required.</p>
 <td>
 <code>-</code><br/>
 <em>
+<a href="https://pkg.go.dev/net/netip#Addr">
 net/netip.Addr
+</a>
 </em>
 </td>
 <td>
@@ -101,7 +103,9 @@ net/netip.Addr
 <td>
 <code>-</code><br/>
 <em>
+<a href="https://pkg.go.dev/net/netip#Prefix">
 net/netip.Prefix
+</a>
 </em>
 </td>
 <td>

--- a/docs/api-reference/compute.md
+++ b/docs/api-reference/compute.md
@@ -119,7 +119,8 @@ string
 </em>
 </td>
 <td>
-<p>Image is the URL providing the operating system image of the machine.</p>
+<em>(Optional)</em>
+<p>Image is the optional URL providing the operating system image of the machine.</p>
 </td>
 </tr>
 <tr>
@@ -165,7 +166,7 @@ Kubernetes core/v1.LocalObjectReference
 <td>
 <code>ignitionRef</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.SecretKeySelector">
+<a href="/api-reference/common.md#secretkeyselector">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.SecretKeySelector
 </a>
 </em>
@@ -192,7 +193,7 @@ If key is empty, DefaultIgnitionKey will be used as fallback.</p>
 <td>
 <code>tolerations</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.Toleration">
+<a href="/api-reference/common.md#toleration">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.Toleration
 </a>
 </em>
@@ -349,7 +350,7 @@ string
 <td>
 <code>taints</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.Taint">
+<a href="/api-reference/common.md#taint">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.Taint
 </a>
 </em>
@@ -511,7 +512,9 @@ object) networking.NetworkInterface.</p>
 <td>
 <code>networkInterfaceTemplate</code><br/>
 <em>
+<a href="/api-reference/networking.md#networking.api.onmetal.de/v1alpha1.NetworkInterfaceTemplateSpec">
 github.com/onmetal/onmetal-api/apis/networking/v1alpha1.NetworkInterfaceTemplateSpec
+</a>
 </em>
 </td>
 <td>
@@ -541,7 +544,9 @@ storage.Volume.</p>
 <td>
 <code>volumeTemplate</code><br/>
 <em>
+<a href="/api-reference/storage.md#storage.api.onmetal.de/v1alpha1.VolumeTemplateSpec">
 github.com/onmetal/onmetal-api/apis/storage/v1alpha1.VolumeTemplateSpec
+</a>
 </em>
 </td>
 <td>
@@ -927,7 +932,7 @@ string
 <td>
 <code>taints</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.Taint">
+<a href="/api-reference/common.md#taint">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.Taint
 </a>
 </em>
@@ -1108,7 +1113,8 @@ string
 </em>
 </td>
 <td>
-<p>Image is the URL providing the operating system image of the machine.</p>
+<em>(Optional)</em>
+<p>Image is the optional URL providing the operating system image of the machine.</p>
 </td>
 </tr>
 <tr>
@@ -1154,7 +1160,7 @@ Kubernetes core/v1.LocalObjectReference
 <td>
 <code>ignitionRef</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.SecretKeySelector">
+<a href="/api-reference/common.md#secretkeyselector">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.SecretKeySelector
 </a>
 </em>
@@ -1181,7 +1187,7 @@ If key is empty, DefaultIgnitionKey will be used as fallback.</p>
 <td>
 <code>tolerations</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.Toleration">
+<a href="/api-reference/common.md#toleration">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.Toleration
 </a>
 </em>
@@ -1463,7 +1469,7 @@ Kubernetes meta/v1.Time
 <td>
 <code>ips</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.IP
 </a>
 </em>
@@ -1476,7 +1482,7 @@ Kubernetes meta/v1.Time
 <td>
 <code>virtualIP</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IP
 </a>
 </em>

--- a/docs/api-reference/ipam.md
+++ b/docs/api-reference/ipam.md
@@ -89,7 +89,7 @@ If unset but Prefix is set, this can be inferred.</p>
 <td>
 <code>prefix</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IPPrefix
 </a>
 </em>
@@ -229,7 +229,7 @@ If unset but Prefix is set, this can be inferred.</p>
 <td>
 <code>prefix</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IPPrefix
 </a>
 </em>
@@ -352,7 +352,7 @@ If unset but Prefix is set, this can be inferred.</p>
 <td>
 <code>prefix</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IPPrefix
 </a>
 </em>
@@ -420,7 +420,7 @@ Kubernetes meta/v1.LabelSelector
 <td>
 <code>prefix</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IPPrefix
 </a>
 </em>
@@ -514,7 +514,7 @@ If unset but Prefix is set, this can be inferred.</p>
 <td>
 <code>prefix</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IPPrefix
 </a>
 </em>
@@ -610,7 +610,7 @@ Kubernetes meta/v1.Time
 <td>
 <code>used</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.IPPrefix
 </a>
 </em>
@@ -678,7 +678,7 @@ If unset but Prefix is set, this can be inferred.</p>
 <td>
 <code>prefix</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IPPrefix
 </a>
 </em>

--- a/docs/api-reference/networking.md
+++ b/docs/api-reference/networking.md
@@ -183,7 +183,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>destinations</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.LocalUIDReference">
+<a href="/api-reference/common.md#localuidreference">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.LocalUIDReference
 </a>
 </em>
@@ -314,7 +314,7 @@ Kubernetes core/v1.LocalObjectReference
 <td>
 <code>machineRef</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.LocalUIDReference">
+<a href="/api-reference/common.md#localuidreference">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.LocalUIDReference
 </a>
 </em>
@@ -467,7 +467,7 @@ Kubernetes core/v1.IPFamily
 <td>
 <code>targetRef</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.LocalUIDReference">
+<a href="/api-reference/common.md#localuidreference">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.LocalUIDReference
 </a>
 </em>
@@ -572,7 +572,7 @@ should be used by this AliasPrefix</p>
 <td>
 <code>prefix</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IPPrefix
 </a>
 </em>
@@ -604,7 +604,7 @@ surrounding object) Prefix.</p>
 <td>
 <code>prefixTemplate</code><br/>
 <em>
-<a href="/api-reference/common/#ipam.onmetal.de/v1alpha1.PrefixTemplateSpec">
+<a href="/api-reference/ipam.md#ipam.api.onmetal.de/v1alpha1.PrefixTemplateSpec">
 github.com/onmetal/onmetal-api/apis/ipam/v1alpha1.PrefixTemplateSpec
 </a>
 </em>
@@ -667,7 +667,7 @@ VirtualIPTemplateSpec
 <td>
 <code>value</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IP
 </a>
 </em>
@@ -750,7 +750,7 @@ Kubernetes core/v1.LocalObjectReference
 <td>
 <code>machineRef</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.LocalUIDReference">
+<a href="/api-reference/common.md#localuidreference">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.LocalUIDReference
 </a>
 </em>
@@ -821,7 +821,7 @@ VirtualIPSource
 <td>
 <code>ips</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.IP
 </a>
 </em>
@@ -834,7 +834,7 @@ VirtualIPSource
 <td>
 <code>virtualIP</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IP
 </a>
 </em>
@@ -928,7 +928,7 @@ Kubernetes core/v1.LocalObjectReference
 <td>
 <code>machineRef</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.LocalUIDReference">
+<a href="/api-reference/common.md#localuidreference">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.LocalUIDReference
 </a>
 </em>
@@ -1002,7 +1002,7 @@ VirtualIPSource
 <td>
 <code>value</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IPPrefix
 </a>
 </em>
@@ -1143,7 +1143,7 @@ Kubernetes core/v1.IPFamily
 <td>
 <code>targetRef</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.LocalUIDReference">
+<a href="/api-reference/common.md#localuidreference">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.LocalUIDReference
 </a>
 </em>
@@ -1174,7 +1174,7 @@ github.com/onmetal/onmetal-api/apis/common/v1alpha1.LocalUIDReference
 <td>
 <code>ip</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.IP">
+<a href="/api-reference/common.md#ip">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.IP
 </a>
 </em>
@@ -1284,7 +1284,7 @@ Kubernetes core/v1.IPFamily
 <td>
 <code>targetRef</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.LocalUIDReference">
+<a href="/api-reference/common.md#localuidreference">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.LocalUIDReference
 </a>
 </em>

--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -115,7 +115,9 @@ If unset, the scheduler will figure out a suitable VolumePoolRef.</p>
 <td>
 <code>claimRef</code><br/>
 <em>
+<a href="/api-reference/common.md#localuidreference">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.LocalUIDReference
+</a>
 </em>
 </td>
 <td>
@@ -174,7 +176,7 @@ bool
 <td>
 <code>tolerations</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.Toleration">
+<a href="/api-reference/common.md#toleration">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.Toleration
 </a>
 </em>
@@ -332,7 +334,7 @@ string
 <td>
 <code>taints</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.Taint">
+<a href="/api-reference/common.md#taint">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.Taint
 </a>
 </em>
@@ -665,7 +667,7 @@ string
 <td>
 <code>taints</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.Taint">
+<a href="/api-reference/common.md#taint">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.Taint
 </a>
 </em>
@@ -838,7 +840,9 @@ If unset, the scheduler will figure out a suitable VolumePoolRef.</p>
 <td>
 <code>claimRef</code><br/>
 <em>
+<a href="/api-reference/common.md#localuidreference">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.LocalUIDReference
+</a>
 </em>
 </td>
 <td>
@@ -897,7 +901,7 @@ bool
 <td>
 <code>tolerations</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.Toleration">
+<a href="/api-reference/common.md#toleration">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.Toleration
 </a>
 </em>
@@ -1114,7 +1118,9 @@ If unset, the scheduler will figure out a suitable VolumePoolRef.</p>
 <td>
 <code>claimRef</code><br/>
 <em>
+<a href="/api-reference/common.md#localuidreference">
 github.com/onmetal/onmetal-api/apis/common/v1alpha1.LocalUIDReference
+</a>
 </em>
 </td>
 <td>
@@ -1173,7 +1179,7 @@ bool
 <td>
 <code>tolerations</code><br/>
 <em>
-<a href="/api-reference/common/#common.onmetal.de/v1alpha1.Toleration">
+<a href="/api-reference/common.md#toleration">
 []github.com/onmetal/onmetal-api/apis/common/v1alpha1.Toleration
 </a>
 </em>

--- a/gen/v3/apis__compute.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__compute.api.onmetal.de__v1alpha1_openapi.json
@@ -18478,8 +18478,7 @@
 				"description": "MachineSpec defines the desired state of Machine",
 				"type": "object",
 				"required": [
-					"machineClassRef",
-					"image"
+					"machineClassRef"
 				],
 				"properties": {
 					"efiVars": {
@@ -18498,7 +18497,7 @@
 						]
 					},
 					"image": {
-						"description": "Image is the URL providing the operating system image of the machine.",
+						"description": "Image is the optional URL providing the operating system image of the machine.",
 						"type": "string"
 					},
 					"imagePullSecret": {

--- a/gen/v3/apis__ipam.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__ipam.api.onmetal.de__v1alpha1_openapi.json
@@ -18478,8 +18478,7 @@
 				"description": "MachineSpec defines the desired state of Machine",
 				"type": "object",
 				"required": [
-					"machineClassRef",
-					"image"
+					"machineClassRef"
 				],
 				"properties": {
 					"efiVars": {
@@ -18498,7 +18497,7 @@
 						]
 					},
 					"image": {
-						"description": "Image is the URL providing the operating system image of the machine.",
+						"description": "Image is the optional URL providing the operating system image of the machine.",
 						"type": "string"
 					},
 					"imagePullSecret": {

--- a/gen/v3/apis__networking.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__networking.api.onmetal.de__v1alpha1_openapi.json
@@ -18478,8 +18478,7 @@
 				"description": "MachineSpec defines the desired state of Machine",
 				"type": "object",
 				"required": [
-					"machineClassRef",
-					"image"
+					"machineClassRef"
 				],
 				"properties": {
 					"efiVars": {
@@ -18498,7 +18497,7 @@
 						]
 					},
 					"image": {
-						"description": "Image is the URL providing the operating system image of the machine.",
+						"description": "Image is the optional URL providing the operating system image of the machine.",
 						"type": "string"
 					},
 					"imagePullSecret": {

--- a/gen/v3/apis__storage.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__storage.api.onmetal.de__v1alpha1_openapi.json
@@ -18478,8 +18478,7 @@
 				"description": "MachineSpec defines the desired state of Machine",
 				"type": "object",
 				"required": [
-					"machineClassRef",
-					"image"
+					"machineClassRef"
 				],
 				"properties": {
 					"efiVars": {
@@ -18498,7 +18497,7 @@
 						]
 					},
 					"image": {
-						"description": "Image is the URL providing the operating system image of the machine.",
+						"description": "Image is the optional URL providing the operating system image of the machine.",
 						"type": "string"
 					},
 					"imagePullSecret": {

--- a/generated/openapi/zz_generated.openapi.go
+++ b/generated/openapi/zz_generated.openapi.go
@@ -1352,8 +1352,7 @@ func schema_onmetal_api_apis_compute_v1alpha1_MachineSpec(ref common.ReferenceCa
 					},
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Image is the URL providing the operating system image of the machine.",
-							Default:     "",
+							Description: "Image is the optional URL providing the operating system image of the machine.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1427,7 +1426,7 @@ func schema_onmetal_api_apis_compute_v1alpha1_MachineSpec(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"machineClassRef", "image"},
+				Required: []string{"machineClassRef"},
 			},
 		},
 		Dependencies: []string{

--- a/hack/api-reference/common-config.json
+++ b/hack/api-reference/common-config.json
@@ -8,12 +8,12 @@
     ],
     "externalPackages": [
         {
-            "typeMatchPrefix": "^inet\\.af/netaddr\\.IP",
-            "docsURLTemplate": "https://pkg.go.dev/inet.af/netaddr#IP"
+            "typeMatchPrefix": "^net/netip\\.Addr",
+            "docsURLTemplate": "https://pkg.go.dev/net/netip#Addr"
         },
         {
-            "typeMatchPrefix": "^inet\\.af/netaddr\\.IPPrefix",
-            "docsURLTemplate": "https://pkg.go.dev/inet.af/netaddr#IPPrefix"
+            "typeMatchPrefix": "^net/netip\\.Prefix",
+            "docsURLTemplate": "https://pkg.go.dev/net/netip#Prefix"
         },
         {
             "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/api/resource\\.Quantity",

--- a/hack/api-reference/compute-config.json
+++ b/hack/api-reference/compute-config.json
@@ -16,32 +16,32 @@
       "docsURLTemplate": "https://v1-23.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
     },
     {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.CIDR",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.CIDR"
-    },
-    {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.IP",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.IP"
-    },
-    {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.Toleration",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.Toleration"
-    },
-    {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.Taint",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.Taint"
-    },
-    {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.IPAddr",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.IPAddr"
-    },
-    {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.SecretKeySelector$",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.SecretKeySelector"
+      "docsURLTemplate": "/api-reference/common.md#secretkeyselector"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.ConfigMapKeySelector$",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.ConfigMapKeySelector"
+      "docsURLTemplate": "/api-reference/common.md#configmapkeyselector"
+    },
+    {
+      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/networking/v1alpha1\\.NetworkInterfaceTemplateSpec",
+      "docsURLTemplate": "/api-reference/networking.md#networking.api.onmetal.de/v1alpha1.NetworkInterfaceTemplateSpec"
+    },
+    {
+      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/storage/v1alpha1\\.VolumeTemplateSpec",
+      "docsURLTemplate": "/api-reference/storage.md#storage.api.onmetal.de/v1alpha1.VolumeTemplateSpec"
+    },
+    {
+      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.IP",
+      "docsURLTemplate": "/api-reference/common.md#ip"
+    },
+    {
+      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.Toleration",
+      "docsURLTemplate": "/api-reference/common.md#toleration"
+    },
+    {
+      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.Taint",
+      "docsURLTemplate": "/api-reference/common.md#taint"
     }
   ],
   "typeDisplayNamePrefixOverrides": {

--- a/hack/api-reference/ipam-config.json
+++ b/hack/api-reference/ipam-config.json
@@ -16,28 +16,20 @@
       "docsURLTemplate": "https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
     },
     {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.CIDR",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.CIDR"
-    },
-    {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.IPAddr",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.IPAddr"
-    },
-    {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.IP",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.IP"
+      "docsURLTemplate": "/api-reference/common.md#ip"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.IPPrefix",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.IPPrefix"
+      "docsURLTemplate": "/api-reference/common.md#ipprefix"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.SecretKeySelector$",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.SecretKeySelector"
+      "docsURLTemplate": "/api-reference/common.md#secretkeyselector"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.ConfigMapKeySelector$",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.ConfigMapKeySelector"
+      "docsURLTemplate": "/api-reference/common.md#configmapkeyselector"
     }
   ],
   "typeDisplayNamePrefixOverrides": {

--- a/hack/api-reference/networking-config.json
+++ b/hack/api-reference/networking-config.json
@@ -16,40 +16,32 @@
       "docsURLTemplate": "https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
     },
     {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.CIDR",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.CIDR"
-    },
-    {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.IPAddr",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.IPAddr"
-    },
-    {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.IP",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.IP"
+      "docsURLTemplate": "/api-reference/common.md#ip"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.IPPrefix",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.IPPrefix"
+      "docsURLTemplate": "/api-reference/common.md#ipprefix"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.LocalUIDReference",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.LocalUIDReference"
+      "docsURLTemplate": "/api-reference/common.md#localuidreference"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/ipam/v1alpha1\\.PrefixSpec",
-      "docsURLTemplate": "/api-reference/common/#ipam.onmetal.de/v1alpha1.PrefixSpec"
+      "docsURLTemplate": "/api-reference/ipam.md#ipam.api.onmetal.de/v1alpha1.PrefixSpec"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/ipam/v1alpha1\\.PrefixTemplateSpec",
-      "docsURLTemplate": "/api-reference/common/#ipam.onmetal.de/v1alpha1.PrefixTemplateSpec"
+      "docsURLTemplate": "/api-reference/ipam.md#ipam.api.onmetal.de/v1alpha1.PrefixTemplateSpec"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.SecretKeySelector$",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.SecretKeySelector"
+      "docsURLTemplate": "/api-reference/common.md#secretkeyselector"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.ConfigMapKeySelector$",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.ConfigMapKeySelector"
+      "docsURLTemplate": "/api-reference/common.md#configmapkeyselector"
     }
   ],
   "typeDisplayNamePrefixOverrides": {

--- a/hack/api-reference/storage-config.json
+++ b/hack/api-reference/storage-config.json
@@ -20,28 +20,24 @@
       "docsURLTemplate": "https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
     },
     {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.CIDR",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.CIDR"
-    },
-    {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.IPAddr",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.IPAddr"
-    },
-    {
-      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.SecretKeySelector$",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.SecretKeySelector"
-    },
-    {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.Toleration",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.Toleration"
+      "docsURLTemplate": "/api-reference/common.md#toleration"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.Taint",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.Taint"
+      "docsURLTemplate": "/api-reference/common.md#taint"
+    },
+    {
+      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.SecretKeySelector$",
+      "docsURLTemplate": "/api-reference/common.md#secretkeyselector"
     },
     {
       "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.ConfigMapKeySelector$",
-      "docsURLTemplate": "/api-reference/common/#common.onmetal.de/v1alpha1.ConfigMapKeySelector"
+      "docsURLTemplate": "/api-reference/common.md#configmapkeyselector"
+    },
+    {
+      "typeMatchPrefix": "^github\\.com/onmetal/onmetal-api/apis/common/v1alpha1\\.LocalUIDReference",
+      "docsURLTemplate": "/api-reference/common.md#localuidreference"
     }
   ],
   "typeDisplayNamePrefixOverrides": {


### PR DESCRIPTION
# Proposed Changes

To support non-RAM boots we want to allow to omit the `.spec.image` field in the `Machine` spec. The image in this case will be referenced by the corresponding `Volume`.

Fixed wrong references in api-references docs.

/cc @gehoern 