### PR TITLE
Increase default NAT Gateway port range from 64 to 2048

### DIFF
--- a/api/networking/v1alpha1/natgateway_type.go
+++ b/api/networking/v1alpha1/natgateway_type.go
@@ -22,6 +22,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// DefaultPortsPerNetworkInterface is the default number of ports per network interface.
+	DefaultPortsPerNetworkInterface int32 = 2048
+)
+
 // NATGatewayType is a type of NATGateway.
 type NATGatewayType string
 
@@ -47,7 +52,7 @@ type NATGatewaySpec struct {
 	// for which this NATGateway should be applied
 	NetworkInterfaceSelector *metav1.LabelSelector `json:"networkInterfaceSelector,omitempty"`
 	// PortsPerNetworkInterface defines the number of concurrent connections per target network interface.
-	// Has to be a power of 2. If empty, 2048 is the default.
+	// Has to be a power of 2. If empty, 2048 (DefaultPortsPerNetworkInterface) is the default.
 	PortsPerNetworkInterface *int32 `json:"portsPerNetworkInterface,omitempty"`
 }
 

--- a/api/networking/v1alpha1/natgateway_type.go
+++ b/api/networking/v1alpha1/natgateway_type.go
@@ -47,7 +47,7 @@ type NATGatewaySpec struct {
 	// for which this NATGateway should be applied
 	NetworkInterfaceSelector *metav1.LabelSelector `json:"networkInterfaceSelector,omitempty"`
 	// PortsPerNetworkInterface defines the number of concurrent connections per target network interface.
-	// Has to be a power of 2. If empty, 64 is the default.
+	// Has to be a power of 2. If empty, 2048 is the default.
 	PortsPerNetworkInterface *int32 `json:"portsPerNetworkInterface,omitempty"`
 }
 

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -3504,7 +3504,7 @@ func schema_onmetal_api_api_networking_v1alpha1_NATGatewaySpec(ref common.Refere
 					},
 					"portsPerNetworkInterface": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PortsPerNetworkInterface defines the number of concurrent connections per target network interface. Has to be a power of 2. If empty, 64 is the default.",
+							Description: "PortsPerNetworkInterface defines the number of concurrent connections per target network interface. Has to be a power of 2. If empty, 2048 (DefaultPortsPerNetworkInterface) is the default.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/docs/api-reference/networking.md
+++ b/docs/api-reference/networking.md
@@ -560,7 +560,7 @@ int32
 </td>
 <td>
 <p>PortsPerNetworkInterface defines the number of concurrent connections per target network interface.
-Has to be a power of 2. If empty, 2048 is the default.</p>
+Has to be a power of 2. If empty, 2048 (DefaultPortsPerNetworkInterface) is the default.</p>
 </td>
 </tr>
 </table>
@@ -1642,7 +1642,7 @@ int32
 </td>
 <td>
 <p>PortsPerNetworkInterface defines the number of concurrent connections per target network interface.
-Has to be a power of 2. If empty, 2048 is the default.</p>
+Has to be a power of 2. If empty, 2048 (DefaultPortsPerNetworkInterface) is the default.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-reference/networking.md
+++ b/docs/api-reference/networking.md
@@ -560,7 +560,7 @@ int32
 </td>
 <td>
 <p>PortsPerNetworkInterface defines the number of concurrent connections per target network interface.
-Has to be a power of 2. If empty, 64 is the default.</p>
+Has to be a power of 2. If empty, 2048 is the default.</p>
 </td>
 </tr>
 </table>
@@ -1642,7 +1642,7 @@ int32
 </td>
 <td>
 <p>PortsPerNetworkInterface defines the number of concurrent connections per target network interface.
-Has to be a power of 2. If empty, 64 is the default.</p>
+Has to be a power of 2. If empty, 2048 is the default.</p>
 </td>
 </tr>
 </tbody>

--- a/internal/apis/networking/natgateway_type.go
+++ b/internal/apis/networking/natgateway_type.go
@@ -22,6 +22,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// DefaultPortsPerNetworkInterface is the default number of ports per network interface.
+	DefaultPortsPerNetworkInterface int32 = 2048
+)
+
 // NATGatewayType is a type of NATGateway.
 type NATGatewayType string
 
@@ -44,7 +49,7 @@ type NATGatewaySpec struct {
 	// for which this NATGateway should be applied
 	NetworkInterfaceSelector *metav1.LabelSelector
 	// PortsPerNetworkInterface defines the number of concurrent connections per target network interface.
-	// Has to be a power of 2. If empty, 2048 is the default.
+	// Has to be a power of 2. If empty, 2048 (DefaultPortsPerNetworkInterface) is the default.
 	PortsPerNetworkInterface *int32
 }
 

--- a/internal/apis/networking/natgateway_type.go
+++ b/internal/apis/networking/natgateway_type.go
@@ -44,7 +44,7 @@ type NATGatewaySpec struct {
 	// for which this NATGateway should be applied
 	NetworkInterfaceSelector *metav1.LabelSelector
 	// PortsPerNetworkInterface defines the number of concurrent connections per target network interface.
-	// Has to be a power of 2. If empty, 64 is the default.
+	// Has to be a power of 2. If empty, 2048 is the default.
 	PortsPerNetworkInterface *int32
 }
 

--- a/internal/apis/networking/v1alpha1/defaults.go
+++ b/internal/apis/networking/v1alpha1/defaults.go
@@ -81,6 +81,6 @@ func SetDefaults_NetworkInterfaceStatus(status *v1alpha1.NetworkInterfaceStatus)
 
 func SetDefaults_NATGatewaySpec(spec *v1alpha1.NATGatewaySpec) {
 	if spec.PortsPerNetworkInterface == nil {
-		spec.PortsPerNetworkInterface = pointer.Int32(64)
+		spec.PortsPerNetworkInterface = pointer.Int32(2048)
 	}
 }

--- a/internal/apis/networking/v1alpha1/defaults.go
+++ b/internal/apis/networking/v1alpha1/defaults.go
@@ -81,6 +81,6 @@ func SetDefaults_NetworkInterfaceStatus(status *v1alpha1.NetworkInterfaceStatus)
 
 func SetDefaults_NATGatewaySpec(spec *v1alpha1.NATGatewaySpec) {
 	if spec.PortsPerNetworkInterface == nil {
-		spec.PortsPerNetworkInterface = pointer.Int32(2048)
+		spec.PortsPerNetworkInterface = pointer.Int32(v1alpha1.DefaultPortsPerNetworkInterface)
 	}
 }

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -478,7 +478,7 @@ var _ = Describe("MachineController", func() {
 			g.Expect(oriNetworkInterface.Spec.Nats).To(ConsistOf(&ori.NATSpec{
 				Ip:      "10.0.0.1",
 				Port:    1024,
-				EndPort: 1087,
+				EndPort: 1024 + networkingv1alpha1.DefaultPortsPerNetworkInterface - 1,
 			}))
 		}).Should(Succeed())
 	})


### PR DESCRIPTION
The default values of NAT gateway port ranges (currently 64) is too low for most use cases. Let's increase the number to 2048. This should be enough for the majority of use cases. Users who want to optimize this value, may reduce it to a size suitable for them.

# Proposed Changes
Increase default value for NAT gateway port range from 64 to 2048.