### PR TITLE
Implement bootstrap token auth for all `*Pool`s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,14 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	$(CONTROLLER_GEN) rbac:roleName=broker-role paths="./broker/bucketbroker/..." output:rbac:artifacts:config=config/bucketpoollet-broker/broker-rbac
 	./hack/replace.sh config/bucketpoollet-broker/broker-rbac/role.yaml 's/ClusterRole/Role/g'
 
+	# poollet system roles
+	cp config/machinepoollet-broker/poollet-rbac/role.yaml config/apiserver/rbac/machinepool_role.yaml
+	./hack/replace.sh config/apiserver/rbac/machinepool_role.yaml 's/manager-role/compute.api.onmetal.de:system:machinepools/g'
+	cp config/volumepoollet-broker/poollet-rbac/role.yaml config/apiserver/rbac/volumepool_role.yaml
+	./hack/replace.sh config/apiserver/rbac/volumepool_role.yaml 's/manager-role/storage.api.onmetal.de:system:volumepools/g'
+	cp config/bucketpoollet-broker/poollet-rbac/role.yaml config/apiserver/rbac/bucketpool_role.yaml
+	./hack/replace.sh config/apiserver/rbac/bucketpool_role.yaml 's/manager-role/storage.api.onmetal.de:system:bucketpools/g'
+
 .PHONY: generate
 generate: vgopath models-schema deepcopy-gen client-gen lister-gen informer-gen defaulter-gen conversion-gen openapi-gen applyconfiguration-gen
 	VGOPATH=$(VGOPATH) \

--- a/api/compute/v1alpha1/common.go
+++ b/api/compute/v1alpha1/common.go
@@ -22,7 +22,18 @@ import (
 const (
 	MachineMachinePoolRefNameField  = "spec.machinePoolRef.name"
 	MachineMachineClassRefNameField = "spec.machineClassRef.name"
+
+	// MachinePoolsGroup is the system rbac group all machine pools are in.
+	MachinePoolsGroup = "compute.api.onmetal.de:system:machinepools"
+
+	// MachinePoolUserNamePrefix is the prefix all machine pool users should have.
+	MachinePoolUserNamePrefix = "compute.api.onmetal.de:system:machinepool:"
 )
+
+// MachinePoolCommonName constructs the common name for a certificate of a machine pool user.
+func MachinePoolCommonName(name string) string {
+	return MachinePoolUserNamePrefix + name
+}
 
 // EphemeralNetworkInterfaceSource is a definition for an ephemeral (i.e. coupled to the lifetime of the surrounding
 // object) networking.NetworkInterface.

--- a/api/storage/v1alpha1/common.go
+++ b/api/storage/v1alpha1/common.go
@@ -20,4 +20,26 @@ const (
 
 	BucketBucketPoolRefNameField  = "spec.bucketPoolRef.name"
 	BucketBucketClassRefNameField = "spec.bucketClassRef.name"
+
+	// VolumePoolsGroup is the system rbac group all volume pools are in.
+	VolumePoolsGroup = "storage.api.onmetal.de:system:volumepools"
+
+	// VolumePoolUserNamePrefix is the prefix all volume pool users should have.
+	VolumePoolUserNamePrefix = "storage.api.onmetal.de:system:volumepool:"
+
+	// BucketPoolsGroup is the system rbac group all bucket pools are in.
+	BucketPoolsGroup = "storage.api.onmetal.de:system:bucketpools"
+
+	// BucketPoolUserNamePrefix is the prefix all bucket pool users should have.
+	BucketPoolUserNamePrefix = "storage.api.onmetal.de:system:bucketpool:"
 )
+
+// VolumePoolCommonName constructs the common name for a certificate of a volume pool user.
+func VolumePoolCommonName(name string) string {
+	return VolumePoolUserNamePrefix + name
+}
+
+// BucketPoolCommonName constructs the common name for a certificate of a bucket pool user.
+func BucketPoolCommonName(name string) string {
+	return BucketPoolUserNamePrefix + name
+}

--- a/config/apiserver/rbac/bucketpool_bootstrapper_role.yaml
+++ b/config/apiserver/rbac/bucketpool_bootstrapper_role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: storage.api.onmetal.de:system:bucketpools-bootstrapper
+rules:
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests/bucketpoolclient
+    verbs:
+      - create

--- a/config/apiserver/rbac/bucketpool_bootstrapper_rolebinding.yaml
+++ b/config/apiserver/rbac/bucketpool_bootstrapper_rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: storage.api.onmetal.de:system:bucketpools-bootstrapper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: storage.api.onmetal.de:system:bucketpools-bootstrapper
+subjects:
+  - kind: Group
+    # Group name has to match bootstrap group pattern \Asystem:bootstrappers:[a-z0-9:-]{0,255}[a-z0-9]\
+    # See https://github.com/kubernetes/kubernetes/blob/e8662a46dd27db774ec953dae15f93ae2d1a68c8/staging/src/k8s.io/cluster-bootstrap/token/api/types.go#L96
+    name: system:bootstrappers:storage-api-onmetal-de:bucketpools
+    apiGroup: rbac.authorization.k8s.io

--- a/config/apiserver/rbac/bucketpool_role.yaml
+++ b/config/apiserver/rbac/bucketpool_role.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: storage.api.onmetal.de:system:bucketpools
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - bucketclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - bucketpools
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - bucketpools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - buckets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - buckets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - buckets/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/config/apiserver/rbac/bucketpool_rolebinding.yaml
+++ b/config/apiserver/rbac/bucketpool_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: storage.api.onmetal.de:system:bucketpools
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: storage.api.onmetal.de:system:bucketpools
+subjects:
+  - kind: Group
+    name: storage.api.onmetal.de:system:bucketpools
+    apiGroup: rbac.authorization.k8s.io

--- a/config/apiserver/rbac/kustomization.yaml
+++ b/config/apiserver/rbac/kustomization.yaml
@@ -1,4 +1,24 @@
 resources:
+  
+  # API Server roles
   - apiserver_service_account.yaml
   - apiserver_role.yaml
   - apiserver_role_binding.yaml
+  
+  # MachinePool (bootstrapper) roles
+  - machinepool_role.yaml
+  - machinepool_rolebinding.yaml
+  - machinepool_bootstrapper_role.yaml
+  - machinepool_bootstrapper_rolebinding.yaml
+  
+  # VolumePool (bootstrapper) roles
+  - volumepool_role.yaml
+  - volumepool_rolebinding.yaml
+  - volumepool_bootstrapper_role.yaml
+  - volumepool_bootstrapper_rolebinding.yaml
+  
+  # BucketPool (bootstrapper) roles
+  - bucketpool_role.yaml
+  - bucketpool_rolebinding.yaml
+  - bucketpool_bootstrapper_role.yaml
+  - bucketpool_bootstrapper_rolebinding.yaml

--- a/config/apiserver/rbac/machinepool_bootstrapper_role.yaml
+++ b/config/apiserver/rbac/machinepool_bootstrapper_role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: storage.api.onmetal.de:system:machinepools-bootstrapper
+rules:
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests/machinepoolclient
+    verbs:
+      - create

--- a/config/apiserver/rbac/machinepool_bootstrapper_rolebinding.yaml
+++ b/config/apiserver/rbac/machinepool_bootstrapper_rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: compute.api.onmetal.de:system:machinepools-bootstrapper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: compute.api.onmetal.de:system:machinepools-bootstrapper
+subjects:
+  - kind: Group
+    # Group name has to match bootstrap group pattern \Asystem:bootstrappers:[a-z0-9:-]{0,255}[a-z0-9]\
+    # See https://github.com/kubernetes/kubernetes/blob/e8662a46dd27db774ec953dae15f93ae2d1a68c8/staging/src/k8s.io/cluster-bootstrap/token/api/types.go#L96
+    name: system:bootstrappers:compute-api-onmetal-de:machinepools
+    apiGroup: rbac.authorization.k8s.io

--- a/config/apiserver/rbac/machinepool_role.yaml
+++ b/config/apiserver/rbac/machinepool_role.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: compute.api.onmetal.de:system:machinepools
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - compute.api.onmetal.de
+  resources:
+  - machineclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - compute.api.onmetal.de
+  resources:
+  - machinepools
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - compute.api.onmetal.de
+  resources:
+  - machinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - compute.api.onmetal.de
+  resources:
+  - machines
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - compute.api.onmetal.de
+  resources:
+  - machines/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - compute.api.onmetal.de
+  resources:
+  - machines/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.api.onmetal.de
+  resources:
+  - aliasprefixes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.api.onmetal.de
+  resources:
+  - aliasprefixroutings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.api.onmetal.de
+  resources:
+  - loadbalancerroutings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.api.onmetal.de
+  resources:
+  - loadbalancers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.api.onmetal.de
+  resources:
+  - natgatewayroutings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.api.onmetal.de
+  resources:
+  - natgateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.api.onmetal.de
+  resources:
+  - networkinterfaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.api.onmetal.de
+  resources:
+  - networks
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.api.onmetal.de
+  resources:
+  - virtualips
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - volumes
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/apiserver/rbac/machinepool_rolebinding.yaml
+++ b/config/apiserver/rbac/machinepool_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: compute.api.onmetal.de:system:machinepools
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: compute.api.onmetal.de:system:machinepools
+subjects:
+  - kind: Group
+    name: compute.api.onmetal.de:system:machinepools
+    apiGroup: rbac.authorization.k8s.io

--- a/config/apiserver/rbac/volumepool_bootstrapper_role.yaml
+++ b/config/apiserver/rbac/volumepool_bootstrapper_role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: storage.api.onmetal.de:system:volumepools-bootstrapper
+rules:
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests/volumepoolclient
+    verbs:
+      - create

--- a/config/apiserver/rbac/volumepool_bootstrapper_rolebinding.yaml
+++ b/config/apiserver/rbac/volumepool_bootstrapper_rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: storage.api.onmetal.de:system:volumepools-bootstrapper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: storage.api.onmetal.de:system:volumepools-bootstrapper
+subjects:
+  - kind: Group
+    # Group name has to match bootstrap group pattern \Asystem:bootstrappers:[a-z0-9:-]{0,255}[a-z0-9]\
+    # See https://github.com/kubernetes/kubernetes/blob/e8662a46dd27db774ec953dae15f93ae2d1a68c8/staging/src/k8s.io/cluster-bootstrap/token/api/types.go#L96
+    name: system:bootstrappers:storage-api-onmetal-de:volumepools
+    apiGroup: rbac.authorization.k8s.io

--- a/config/apiserver/rbac/volumepool_role.yaml
+++ b/config/apiserver/rbac/volumepool_role.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: storage.api.onmetal.de:system:volumepools
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - volumeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - volumepools
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - volumepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - volumes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - volumes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - storage.api.onmetal.de
+  resources:
+  - volumes/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/config/apiserver/rbac/volumepool_rolebinding.yaml
+++ b/config/apiserver/rbac/volumepool_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: storage.api.onmetal.de:system:volumepools
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: storage.api.onmetal.de:system:volumepools
+subjects:
+  - kind: Group
+    name: storage.api.onmetal.de:system:volumepools
+    apiGroup: rbac.authorization.k8s.io

--- a/config/controller/rbac/role.yaml
+++ b/config/controller/rbac/role.yaml
@@ -23,6 +23,36 @@ rules:
   - update
   - watch
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/approval
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - certificates.k8s.io
+  resourceNames:
+  - kubernetes.io/kube-apiserver-client
+  resources:
+  - signers
+  verbs:
+  - approve
+- apiGroups:
   - compute.api.onmetal.de
   resources:
   - machineclasses

--- a/internal/apis/compute/common.go
+++ b/internal/apis/compute/common.go
@@ -22,7 +22,18 @@ import (
 const (
 	MachineMachinePoolRefNameField  = "spec.machinePoolRef.name"
 	MachineMachineClassRefNameField = "spec.machineClassRef.name"
+
+	// MachinePoolsGroup is the system rbac group all machine pools are in.
+	MachinePoolsGroup = "compute.api.onmetal.de:system:machinepools"
+
+	// MachinePoolUserNamePrefix is the prefix all machine pool users should have.
+	MachinePoolUserNamePrefix = "compute.api.onmetal.de:system:machinepool:"
 )
+
+// MachinePoolCommonName constructs the common name for a certificate of a machine pool user.
+func MachinePoolCommonName(name string) string {
+	return MachinePoolUserNamePrefix + name
+}
 
 // EphemeralNetworkInterfaceSource is a definition for an ephemeral (i.e. coupled to the lifetime of the surrounding
 // object) networking.NetworkInterface.

--- a/internal/apis/storage/common.go
+++ b/internal/apis/storage/common.go
@@ -20,4 +20,26 @@ const (
 
 	BucketBucketPoolRefNameField  = "spec.bucketPoolRef.name"
 	BucketBucketClassRefNameField = "spec.bucketClassRef.name"
+
+	// VolumePoolsGroup is the system rbac group all volume pools are in.
+	VolumePoolsGroup = "storage.api.onmetal.de:system:volumepools"
+
+	// VolumePoolUserNamePrefix is the prefix all volume pool users should have.
+	VolumePoolUserNamePrefix = "storage.api.onmetal.de:system:volumepool:"
+
+	// BucketPoolsGroup is the system rbac group all bucket pools are in.
+	BucketPoolsGroup = "storage.api.onmetal.de:system:bucketpools"
+
+	// BucketPoolUserNamePrefix is the prefix all bucket pool users should have.
+	BucketPoolUserNamePrefix = "storage.api.onmetal.de:system:bucketpool:"
 )
+
+// VolumePoolCommonName constructs the common name for a certificate of a volume pool user.
+func VolumePoolCommonName(name string) string {
+	return VolumePoolUserNamePrefix + name
+}
+
+// BucketPoolCommonName constructs the common name for a certificate of a bucket pool user.
+func BucketPoolCommonName(name string) string {
+	return BucketPoolUserNamePrefix + name
+}

--- a/internal/controllers/core/certificate/compute/compute.go
+++ b/internal/controllers/core/certificate/compute/compute.go
@@ -1,0 +1,19 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+import "github.com/onmetal/onmetal-api/internal/controllers/core/certificate/generic"
+
+var Recognizers []generic.CertificateSigningRequestRecognizer

--- a/internal/controllers/core/certificate/compute/machinepool.go
+++ b/internal/controllers/core/certificate/compute/machinepool.go
@@ -1,0 +1,90 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+
+	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
+	"github.com/onmetal/onmetal-api/internal/controllers/core/certificate/generic"
+	"golang.org/x/exp/slices"
+	authv1 "k8s.io/api/authorization/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	MachinePoolRequiredUsages = sets.New[certificatesv1.KeyUsage](
+		certificatesv1.UsageDigitalSignature,
+		certificatesv1.UsageKeyEncipherment,
+		certificatesv1.UsageClientAuth,
+	)
+)
+
+func IsMachinePoolClientCert(csr *certificatesv1.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
+	if csr.Spec.SignerName != certificatesv1.KubeAPIServerClientSignerName {
+		return false
+	}
+
+	return ValidateMachinePoolClientCSR(x509cr, sets.New(csr.Spec.Usages...)) == nil
+}
+
+func ValidateMachinePoolClientCSR(req *x509.CertificateRequest, usages sets.Set[certificatesv1.KeyUsage]) error {
+	if !slices.Equal([]string{computev1alpha1.MachinePoolsGroup}, req.Subject.Organization) {
+		return fmt.Errorf("organization is not %s", computev1alpha1.MachinePoolsGroup)
+	}
+
+	if len(req.DNSNames) > 0 {
+		return fmt.Errorf("dns subject alternative names are not allowed")
+	}
+	if len(req.EmailAddresses) > 0 {
+		return fmt.Errorf("email subject alternative names are not allowed")
+	}
+	if len(req.IPAddresses) > 0 {
+		return fmt.Errorf("ip subject alternative names are not allowed")
+	}
+	if len(req.URIs) > 0 {
+		return fmt.Errorf("uri subject alternative names are not allowed")
+	}
+
+	if !strings.HasPrefix(req.Subject.CommonName, computev1alpha1.MachinePoolUserNamePrefix) {
+		return fmt.Errorf("subject common name does not begin with %s", computev1alpha1.MachinePoolUserNamePrefix)
+	}
+
+	if !MachinePoolRequiredUsages.Equal(usages) {
+		return fmt.Errorf("usages did not match %v", sets.List(MachinePoolRequiredUsages))
+	}
+
+	return nil
+}
+
+var (
+	MachinePoolRecognizer = generic.NewCertificateSigningRequestRecognizer(
+		IsMachinePoolClientCert,
+		authv1.ResourceAttributes{
+			Group:       certificatesv1.GroupName,
+			Resource:    "certificatesigningrequests",
+			Verb:        "create",
+			Subresource: "machinepoolclient",
+		},
+		"Auto approving machine pool client certificate after SubjectAccessReview.",
+	)
+)
+
+func init() {
+	Recognizers = append(Recognizers, MachinePoolRecognizer)
+}

--- a/internal/controllers/core/certificate/generic/certificate.go
+++ b/internal/controllers/core/certificate/generic/certificate.go
@@ -1,0 +1,95 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generic
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	authv1 "k8s.io/api/authorization/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+)
+
+type CertificateSigningRequestRecognizer interface {
+	Recognize(csr *certificatesv1.CertificateSigningRequest, x509CR *x509.CertificateRequest) bool
+	Permission() authv1.ResourceAttributes
+	SuccessMessage() string
+}
+
+type certificateSigningRequestRecognizer struct {
+	recognize      func(csr *certificatesv1.CertificateSigningRequest, x509CR *x509.CertificateRequest) bool
+	permission     authv1.ResourceAttributes
+	successMessage string
+}
+
+func NewCertificateSigningRequestRecognizer(
+	recognize func(csr *certificatesv1.CertificateSigningRequest, x509CR *x509.CertificateRequest) bool,
+	permission authv1.ResourceAttributes,
+	successMessage string,
+) CertificateSigningRequestRecognizer {
+	return &certificateSigningRequestRecognizer{
+		recognize:      recognize,
+		permission:     permission,
+		successMessage: successMessage,
+	}
+}
+
+func (r *certificateSigningRequestRecognizer) Recognize(csr *certificatesv1.CertificateSigningRequest, x509CR *x509.CertificateRequest) bool {
+	return r.recognize(csr, x509CR)
+}
+
+func (r *certificateSigningRequestRecognizer) Permission() authv1.ResourceAttributes {
+	return r.permission
+}
+
+func (r *certificateSigningRequestRecognizer) SuccessMessage() string {
+	return r.successMessage
+}
+
+const (
+	CertificateRequestPEMBlockType = "CERTIFICATE REQUEST"
+)
+
+func ParseCertificateRequest(pemBytes []byte) (*x509.CertificateRequest, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != CertificateRequestPEMBlockType {
+		return nil, fmt.Errorf("pem block type must be %s", CertificateRequestPEMBlockType)
+	}
+
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return csr, nil
+}
+
+func GetCertificateSigningRequestApprovalCondition(status *certificatesv1.CertificateSigningRequestStatus) (approved, denied bool) {
+	for _, c := range status.Conditions {
+		if c.Type == certificatesv1.CertificateApproved {
+			approved = true
+		}
+		if c.Type == certificatesv1.CertificateDenied {
+			denied = true
+		}
+	}
+	return approved, denied
+}
+
+func IsCertificateSigningRequestApproved(csr *certificatesv1.CertificateSigningRequest) bool {
+	approved, denied := GetCertificateSigningRequestApprovalCondition(&csr.Status)
+	return approved && !denied
+}

--- a/internal/controllers/core/certificate/onmetal/onmetal.go
+++ b/internal/controllers/core/certificate/onmetal/onmetal.go
@@ -1,0 +1,28 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package onmetal
+
+import (
+	"github.com/onmetal/onmetal-api/internal/controllers/core/certificate/compute"
+	"github.com/onmetal/onmetal-api/internal/controllers/core/certificate/generic"
+	"github.com/onmetal/onmetal-api/internal/controllers/core/certificate/storage"
+)
+
+var Recognizers []generic.CertificateSigningRequestRecognizer
+
+func init() {
+	Recognizers = append(Recognizers, compute.Recognizers...)
+	Recognizers = append(Recognizers, storage.Recognizers...)
+}

--- a/internal/controllers/core/certificate/storage/bucketpool.go
+++ b/internal/controllers/core/certificate/storage/bucketpool.go
@@ -1,0 +1,90 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+
+	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
+	"github.com/onmetal/onmetal-api/internal/controllers/core/certificate/generic"
+	"golang.org/x/exp/slices"
+	authv1 "k8s.io/api/authorization/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	BucketPoolRequiredUsages = sets.New[certificatesv1.KeyUsage](
+		certificatesv1.UsageDigitalSignature,
+		certificatesv1.UsageKeyEncipherment,
+		certificatesv1.UsageClientAuth,
+	)
+)
+
+func IsBucketPoolClientCert(csr *certificatesv1.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
+	if csr.Spec.SignerName != certificatesv1.KubeAPIServerClientSignerName {
+		return false
+	}
+
+	return ValidateBucketPoolClientCSR(x509cr, sets.New(csr.Spec.Usages...)) == nil
+}
+
+func ValidateBucketPoolClientCSR(req *x509.CertificateRequest, usages sets.Set[certificatesv1.KeyUsage]) error {
+	if !slices.Equal([]string{storagev1alpha1.BucketPoolsGroup}, req.Subject.Organization) {
+		return fmt.Errorf("organization is not %s", storagev1alpha1.BucketPoolsGroup)
+	}
+
+	if len(req.DNSNames) > 0 {
+		return fmt.Errorf("dns subject alternative names are not allowed")
+	}
+	if len(req.EmailAddresses) > 0 {
+		return fmt.Errorf("email subject alternative names are not allowed")
+	}
+	if len(req.IPAddresses) > 0 {
+		return fmt.Errorf("ip subject alternative names are not allowed")
+	}
+	if len(req.URIs) > 0 {
+		return fmt.Errorf("uri subject alternative names are not allowed")
+	}
+
+	if !strings.HasPrefix(req.Subject.CommonName, storagev1alpha1.BucketPoolUserNamePrefix) {
+		return fmt.Errorf("subject common name does not begin with %s", storagev1alpha1.BucketPoolUserNamePrefix)
+	}
+
+	if !BucketPoolRequiredUsages.Equal(usages) {
+		return fmt.Errorf("usages did not match %v", sets.List(BucketPoolRequiredUsages))
+	}
+
+	return nil
+}
+
+var (
+	BucketPoolRecognizer = generic.NewCertificateSigningRequestRecognizer(
+		IsBucketPoolClientCert,
+		authv1.ResourceAttributes{
+			Group:       certificatesv1.GroupName,
+			Resource:    "certificatesigningrequests",
+			Verb:        "create",
+			Subresource: "bucketpoolclient",
+		},
+		"Auto approving bucket pool client certificate after SubjectAccessReview.",
+	)
+)
+
+func init() {
+	Recognizers = append(Recognizers, BucketPoolRecognizer)
+}

--- a/internal/controllers/core/certificate/storage/storage.go
+++ b/internal/controllers/core/certificate/storage/storage.go
@@ -1,0 +1,19 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import "github.com/onmetal/onmetal-api/internal/controllers/core/certificate/generic"
+
+var Recognizers []generic.CertificateSigningRequestRecognizer

--- a/internal/controllers/core/certificate/storage/volumepool.go
+++ b/internal/controllers/core/certificate/storage/volumepool.go
@@ -1,0 +1,90 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+
+	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
+	"github.com/onmetal/onmetal-api/internal/controllers/core/certificate/generic"
+	"golang.org/x/exp/slices"
+	authv1 "k8s.io/api/authorization/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	VolumePoolRequiredUsages = sets.New[certificatesv1.KeyUsage](
+		certificatesv1.UsageDigitalSignature,
+		certificatesv1.UsageKeyEncipherment,
+		certificatesv1.UsageClientAuth,
+	)
+)
+
+func IsVolumePoolClientCert(csr *certificatesv1.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
+	if csr.Spec.SignerName != certificatesv1.KubeAPIServerClientSignerName {
+		return false
+	}
+
+	return ValidateVolumePoolClientCSR(x509cr, sets.New(csr.Spec.Usages...)) == nil
+}
+
+func ValidateVolumePoolClientCSR(req *x509.CertificateRequest, usages sets.Set[certificatesv1.KeyUsage]) error {
+	if !slices.Equal([]string{storagev1alpha1.VolumePoolsGroup}, req.Subject.Organization) {
+		return fmt.Errorf("organization is not %s", storagev1alpha1.VolumePoolsGroup)
+	}
+
+	if len(req.DNSNames) > 0 {
+		return fmt.Errorf("dns subject alternative names are not allowed")
+	}
+	if len(req.EmailAddresses) > 0 {
+		return fmt.Errorf("email subject alternative names are not allowed")
+	}
+	if len(req.IPAddresses) > 0 {
+		return fmt.Errorf("ip subject alternative names are not allowed")
+	}
+	if len(req.URIs) > 0 {
+		return fmt.Errorf("uri subject alternative names are not allowed")
+	}
+
+	if !strings.HasPrefix(req.Subject.CommonName, storagev1alpha1.VolumePoolUserNamePrefix) {
+		return fmt.Errorf("subject common name does not begin with %s", storagev1alpha1.VolumePoolUserNamePrefix)
+	}
+
+	if !VolumePoolRequiredUsages.Equal(usages) {
+		return fmt.Errorf("usages did not match %v", sets.List(VolumePoolRequiredUsages))
+	}
+
+	return nil
+}
+
+var (
+	VolumePoolRecognizer = generic.NewCertificateSigningRequestRecognizer(
+		IsVolumePoolClientCert,
+		authv1.ResourceAttributes{
+			Group:       certificatesv1.GroupName,
+			Resource:    "certificatesigningrequests",
+			Verb:        "create",
+			Subresource: "volumepoolclient",
+		},
+		"Auto approving volume pool client certificate after SubjectAccessReview.",
+	)
+)
+
+func init() {
+	Recognizers = append(Recognizers, VolumePoolRecognizer)
+}

--- a/internal/controllers/core/certificateapproval_controller.go
+++ b/internal/controllers/core/certificateapproval_controller.go
@@ -1,0 +1,126 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onmetal/onmetal-api/internal/controllers/core/certificate/generic"
+	authv1 "k8s.io/api/authorization/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CertificateApprovalReconciler struct {
+	client.Client
+
+	Recognizers []generic.CertificateSigningRequestRecognizer
+}
+
+//+kubebuilder:rbac:groups=certificates.k8s.io,resources=signers,resourceNames=kubernetes.io/kube-apiserver-client,verbs=approve
+//+kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=get;list;watch
+//+kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests/approval,verbs=get;update;patch
+//+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+
+func (r *CertificateApprovalReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	csr := &certificatesv1.CertificateSigningRequest{}
+	if err := r.Get(ctx, req.NamespacedName, csr); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if len(csr.Status.Certificate) > 0 {
+		log.V(1).Info("Certificate already present, nothing to do")
+		return ctrl.Result{}, nil
+	}
+
+	if approved, denied := generic.GetCertificateSigningRequestApprovalCondition(&csr.Status); approved || denied {
+		log.V(1).Info("Certificate approval already marked", "Approved", approved, "Denied", denied)
+		return ctrl.Result{}, nil
+	}
+
+	x509CR, err := generic.ParseCertificateRequest(csr.Spec.Request)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error parsing csr: %w", err)
+	}
+
+	var tried []string
+	for _, recognizer := range r.Recognizers {
+		if recognizer.Recognize(csr, x509CR) {
+			continue
+		}
+
+		permission := recognizer.Permission()
+		tried = append(tried, permission.Subresource)
+
+		approved, err := r.authorize(ctx, csr, permission)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("error approving permission subresource %s: %w",
+				permission.Subresource,
+				err,
+			)
+		}
+		if approved {
+			appendApprovalCondition(csr, recognizer.SuccessMessage())
+			if err := r.Client.SubResource("approval").Update(ctx, csr); err != nil {
+				return ctrl.Result{}, fmt.Errorf("error updating approval for certificate signing request: %w", err)
+			}
+		}
+	}
+	if len(tried) > 0 {
+		log.V(1).Info("Recognized certificate signing request but access review was not approved", "Tried", tried)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *CertificateApprovalReconciler) authorize(ctx context.Context, csr *certificatesv1.CertificateSigningRequest, attrs authv1.ResourceAttributes) (bool, error) {
+	extra := make(map[string]authv1.ExtraValue)
+	for k, v := range csr.Spec.Extra {
+		extra[k] = authv1.ExtraValue(v)
+	}
+
+	sar := &authv1.SubjectAccessReview{
+		Spec: authv1.SubjectAccessReviewSpec{
+			User:               csr.Spec.Username,
+			UID:                csr.Spec.UID,
+			Groups:             csr.Spec.Groups,
+			Extra:              extra,
+			ResourceAttributes: &attrs,
+		},
+	}
+	if err := r.Client.Create(ctx, sar); err != nil {
+		return false, fmt.Errorf("error creating subject access review: %w", err)
+	}
+	return sar.Status.Allowed, nil
+}
+
+func (r *CertificateApprovalReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&certificatesv1.CertificateSigningRequest{}).
+		Complete(r)
+}
+
+func appendApprovalCondition(csr *certificatesv1.CertificateSigningRequest, message string) {
+	csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+		Type:    certificatesv1.CertificateApproved,
+		Status:  corev1.ConditionTrue,
+		Reason:  "AutoApproved",
+		Message: message,
+	})
+}

--- a/internal/controllers/core/certificateapproval_test.go
+++ b/internal/controllers/core/certificateapproval_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+
+	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
+	utilcertificate "github.com/onmetal/onmetal-api/utils/certificate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+)
+
+var _ = Describe("CertificateApprovalController", func() {
+	It("should approve the certificate", func(ctx SpecContext) {
+		By("creating a certificate signing request")
+		csr, _, _, err := utilcertificate.GenerateAndCreateCertificateSigningRequest(
+			ctx,
+			k8sClient,
+			certificatesv1.KubeAPIServerClientSignerName,
+			&x509.CertificateRequest{
+				Subject: pkix.Name{
+					CommonName:   computev1alpha1.MachinePoolCommonName("my-pool"),
+					Organization: []string{computev1alpha1.MachinePoolsGroup},
+				},
+			},
+			utilcertificate.DefaultKubeAPIServerClientGetUsages,
+			nil,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for the csr to be approved and a certificate to be available")
+		Eventually(ctx, Object(csr)).Should(
+			HaveField("Status.Conditions", ContainElement(SatisfyAll(
+				HaveField("Type", certificatesv1.CertificateApproved),
+				HaveField("Status", corev1.ConditionTrue),
+			))),
+		)
+	})
+})

--- a/internal/controllers/core/core_suite_test.go
+++ b/internal/controllers/core/core_suite_test.go
@@ -25,6 +25,7 @@ import (
 	corev1alpha1 "github.com/onmetal/onmetal-api/api/core/v1alpha1"
 	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
 	"github.com/onmetal/onmetal-api/internal/controllers/core"
+	certificateonmetal "github.com/onmetal/onmetal-api/internal/controllers/core/certificate/onmetal"
 	quotacontrollergeneric "github.com/onmetal/onmetal-api/internal/controllers/core/quota/generic"
 	quotacontrolleronmetal "github.com/onmetal/onmetal-api/internal/controllers/core/quota/onmetal"
 	quotaevaluatoronmetal "github.com/onmetal/onmetal-api/internal/quota/evaluator/onmetal"
@@ -126,6 +127,11 @@ var _ = BeforeSuite(func() {
 		APIReader: k8sManager.GetAPIReader(),
 		Scheme:    scheme.Scheme,
 		Registry:  registry,
+	}).SetupWithManager(k8sManager)).To(Succeed())
+
+	Expect((&core.CertificateApprovalReconciler{
+		Client:      k8sManager.GetClient(),
+		Recognizers: certificateonmetal.Recognizers,
 	}).SetupWithManager(k8sManager)).To(Succeed())
 
 	mgrCtx, cancel := context.WithCancel(context.Background())

--- a/ori/apis/bucket/v1alpha1/api.pb.go
+++ b/ori/apis/bucket/v1alpha1/api.pb.go
@@ -1916,7 +1916,7 @@ func (this *BucketClass) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&BucketClass{`,
-		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`RotatorName:` + fmt.Sprintf("%v", this.Name) + `,`,
 		`Capabilities:` + strings.Replace(this.Capabilities.String(), "BucketClassCapabilities", "BucketClassCapabilities", 1) + `,`,
 		`}`,
 	}, "")
@@ -2712,7 +2712,7 @@ func (m *BucketClass) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RotatorName", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {

--- a/ori/apis/machine/v1alpha1/api.pb.go
+++ b/ori/apis/machine/v1alpha1/api.pb.go
@@ -1610,7 +1610,7 @@ func (m *VersionRequest) GetVersion() string {
 }
 
 type VersionResponse struct {
-	// Name of the machine runtime.
+	// RotatorName of the machine runtime.
 	RuntimeName string `protobuf:"bytes,1,opt,name=runtime_name,json=runtimeName,proto3" json:"runtime_name,omitempty"`
 	// Version of the machine runtime. The string must be
 	// semver-compatible.
@@ -9612,7 +9612,7 @@ func (this *VolumeAttachment) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&VolumeAttachment{`,
-		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`RotatorName:` + fmt.Sprintf("%v", this.Name) + `,`,
 		`Device:` + fmt.Sprintf("%v", this.Device) + `,`,
 		`VolumeId:` + fmt.Sprintf("%v", this.VolumeId) + `,`,
 		`EmptyDisk:` + strings.Replace(this.EmptyDisk.String(), "EmptyDiskSpec", "EmptyDiskSpec", 1) + `,`,
@@ -9625,7 +9625,7 @@ func (this *NetworkInterfaceAttachment) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&NetworkInterfaceAttachment{`,
-		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`RotatorName:` + fmt.Sprintf("%v", this.Name) + `,`,
 		`NetworkInterfaceId:` + fmt.Sprintf("%v", this.NetworkInterfaceId) + `,`,
 		`}`,
 	}, "")
@@ -9685,7 +9685,7 @@ func (this *VolumeAttachmentStatus) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&VolumeAttachmentStatus{`,
-		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`RotatorName:` + fmt.Sprintf("%v", this.Name) + `,`,
 		`VolumeHandle:` + fmt.Sprintf("%v", this.VolumeHandle) + `,`,
 		`State:` + fmt.Sprintf("%v", this.State) + `,`,
 		`}`,
@@ -9697,7 +9697,7 @@ func (this *NetworkInterfaceAttachmentStatus) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&NetworkInterfaceAttachmentStatus{`,
-		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`RotatorName:` + fmt.Sprintf("%v", this.Name) + `,`,
 		`NetworkInterfaceHandle:` + fmt.Sprintf("%v", this.NetworkInterfaceHandle) + `,`,
 		`State:` + fmt.Sprintf("%v", this.State) + `,`,
 		`}`,
@@ -9709,7 +9709,7 @@ func (this *MachineClass) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&MachineClass{`,
-		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`RotatorName:` + fmt.Sprintf("%v", this.Name) + `,`,
 		`Capabilities:` + strings.Replace(this.Capabilities.String(), "MachineClassCapabilities", "MachineClassCapabilities", 1) + `,`,
 		`}`,
 	}, "")
@@ -9876,7 +9876,7 @@ func (this *DeleteVolumeAttachmentRequest) String() string {
 	}
 	s := strings.Join([]string{`&DeleteVolumeAttachmentRequest{`,
 		`MachineId:` + fmt.Sprintf("%v", this.MachineId) + `,`,
-		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`RotatorName:` + fmt.Sprintf("%v", this.Name) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -9916,7 +9916,7 @@ func (this *DeleteNetworkInterfaceAttachmentRequest) String() string {
 	}
 	s := strings.Join([]string{`&DeleteNetworkInterfaceAttachmentRequest{`,
 		`MachineId:` + fmt.Sprintf("%v", this.MachineId) + `,`,
-		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`RotatorName:` + fmt.Sprintf("%v", this.Name) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -12802,7 +12802,7 @@ func (m *VolumeAttachment) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RotatorName", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -12984,7 +12984,7 @@ func (m *NetworkInterfaceAttachment) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RotatorName", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -13527,7 +13527,7 @@ func (m *VolumeAttachmentStatus) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RotatorName", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -13660,7 +13660,7 @@ func (m *NetworkInterfaceAttachmentStatus) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RotatorName", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -13793,7 +13793,7 @@ func (m *MachineClass) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RotatorName", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -15191,7 +15191,7 @@ func (m *DeleteVolumeAttachmentRequest) Unmarshal(dAtA []byte) error {
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RotatorName", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
@@ -15523,7 +15523,7 @@ func (m *DeleteNetworkInterfaceAttachmentRequest) Unmarshal(dAtA []byte) error {
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RotatorName", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {

--- a/ori/apis/volume/v1alpha1/api.pb.go
+++ b/ori/apis/volume/v1alpha1/api.pb.go
@@ -2118,7 +2118,7 @@ func (this *VolumeClass) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&VolumeClass{`,
-		`Name:` + fmt.Sprintf("%v", this.Name) + `,`,
+		`RotatorName:` + fmt.Sprintf("%v", this.Name) + `,`,
 		`Capabilities:` + strings.Replace(this.Capabilities.String(), "VolumeClassCapabilities", "VolumeClassCapabilities", 1) + `,`,
 		`}`,
 	}, "")
@@ -3063,7 +3063,7 @@ func (m *VolumeClass) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RotatorName", wireType)
 			}
 			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {

--- a/poollet/bucketpoollet/client/config/getter.go
+++ b/poollet/bucketpoollet/client/config/getter.go
@@ -1,0 +1,52 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"os"
+
+	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
+	utilcertificate "github.com/onmetal/onmetal-api/utils/certificate"
+	"github.com/onmetal/onmetal-api/utils/client/config"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var log = ctrl.Log.WithName("client").WithName("config")
+
+func NewGetter(bucketPoolName string) (*config.Getter, error) {
+	return config.NewGetter(config.GetterOptions{
+		Name:       "bucketpoollet",
+		SignerName: certificatesv1.KubeAPIServerClientSignerName,
+		Template: &x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName:   storagev1alpha1.BucketPoolCommonName(bucketPoolName),
+				Organization: []string{storagev1alpha1.BucketPoolsGroup},
+			},
+		},
+		GetUsages: utilcertificate.DefaultKubeAPIServerClientGetUsages,
+	})
+}
+
+func NewGetterOrDie(bucketPoolName string) *config.Getter {
+	getter, err := NewGetter(bucketPoolName)
+	if err != nil {
+		log.Error(err, "Error creating getter")
+		os.Exit(1)
+	}
+	return getter
+}

--- a/poollet/bucketpoollet/cmd/bucketpoollet/app/app.go
+++ b/poollet/bucketpoollet/cmd/bucketpoollet/app/app.go
@@ -28,8 +28,10 @@ import (
 	ori "github.com/onmetal/onmetal-api/ori/apis/bucket/v1alpha1"
 	oriremotebucket "github.com/onmetal/onmetal-api/ori/remote/bucket"
 	"github.com/onmetal/onmetal-api/poollet/bucketpoollet/bcm"
+	bucketpoolletconfig "github.com/onmetal/onmetal-api/poollet/bucketpoollet/client/config"
 	"github.com/onmetal/onmetal-api/poollet/bucketpoollet/controllers"
 	"github.com/onmetal/onmetal-api/poollet/orievent"
+	"github.com/onmetal/onmetal-api/utils/client/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
@@ -55,8 +57,7 @@ func init() {
 }
 
 type Options struct {
-	Kubeconfig               string
-	EgressSelectorConfig     string
+	GetConfigOptions         config.GetConfigOptions
 	MetricsAddr              string
 	EnableLeaderElection     bool
 	LeaderElectionNamespace  string
@@ -74,8 +75,7 @@ type Options struct {
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.Kubeconfig, "kubeconfig", "", "Path pointing to a kubeconfig to use.")
-	fs.StringVar(&o.EgressSelectorConfig, "egress-selector-config", "", "Path pointing to an egress selector config to use.")
+	o.GetConfigOptions.BindFlags(fs)
 	fs.StringVar(&o.MetricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	fs.StringVar(&o.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	fs.BoolVar(&o.EnableLeaderElection, "leader-elect", false,
@@ -132,6 +132,12 @@ func Run(ctx context.Context, opts Options) error {
 	logger := ctrl.LoggerFrom(ctx)
 	setupLog := ctrl.Log.WithName("setup")
 
+	getter, err := bucketpoolletconfig.NewGetter(opts.BucketPoolName)
+	if err != nil {
+		setupLog.Error(err, "Error creating new getter")
+		os.Exit(1)
+	}
+
 	endpoint, err := oriremotebucket.GetAddressWithTimeout(opts.BucketRuntimeSocketDiscoveryTimeout, opts.BucketRuntimeEndpoint)
 	if err != nil {
 		return fmt.Errorf("error detecting bucket runtime endpoint: %w", err)
@@ -151,10 +157,9 @@ func Run(ctx context.Context, opts Options) error {
 
 	bucketRuntime := ori.NewBucketRuntimeClient(conn)
 
-	cfg, err := configutils.GetConfig(
-		configutils.Kubeconfig(opts.Kubeconfig),
-		configutils.EgressSelectorConfig(opts.EgressSelectorConfig),
-		configutils.WithEgressSelectionName(configutils.EgressSelectionNameControlPlane),
+	cfg, configCtrl, err := getter.GetConfig(ctx,
+		&opts.GetConfigOptions,
+		config.WithEgressSelectionName(configutils.EgressSelectionNameControlPlane),
 	)
 	if err != nil {
 		return fmt.Errorf("error getting config: %w", err)
@@ -180,6 +185,9 @@ func Run(ctx context.Context, opts Options) error {
 	})
 	if err != nil {
 		return fmt.Errorf("error creating manager: %w", err)
+	}
+	if err := config.SetupControllerWithManager(mgr, configCtrl); err != nil {
+		return err
 	}
 
 	bucketClassMapper := bcm.NewGeneric(bucketRuntime, bcm.GenericOptions{})

--- a/poollet/machinepoollet/client/config/getter.go
+++ b/poollet/machinepoollet/client/config/getter.go
@@ -1,0 +1,52 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"os"
+
+	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
+	utilcertificate "github.com/onmetal/onmetal-api/utils/certificate"
+	"github.com/onmetal/onmetal-api/utils/client/config"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var log = ctrl.Log.WithName("client").WithName("config")
+
+func NewGetter(machinePoolName string) (*config.Getter, error) {
+	return config.NewGetter(config.GetterOptions{
+		Name:       "machinepoollet",
+		SignerName: certificatesv1.KubeAPIServerClientSignerName,
+		Template: &x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName:   computev1alpha1.MachinePoolCommonName(machinePoolName),
+				Organization: []string{computev1alpha1.MachinePoolsGroup},
+			},
+		},
+		GetUsages: utilcertificate.DefaultKubeAPIServerClientGetUsages,
+	})
+}
+
+func NewGetterOrDie(machinePoolName string) *config.Getter {
+	getter, err := NewGetter(machinePoolName)
+	if err != nil {
+		log.Error(err, "Error creating getter")
+		os.Exit(1)
+	}
+	return getter
+}

--- a/poollet/volumepoollet/client/config/getter.go
+++ b/poollet/volumepoollet/client/config/getter.go
@@ -1,0 +1,52 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"os"
+
+	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
+	utilcertificate "github.com/onmetal/onmetal-api/utils/certificate"
+	"github.com/onmetal/onmetal-api/utils/client/config"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var log = ctrl.Log.WithName("client").WithName("config")
+
+func NewGetter(volumePoolName string) (*config.Getter, error) {
+	return config.NewGetter(config.GetterOptions{
+		Name:       "volumepoollet",
+		SignerName: certificatesv1.KubeAPIServerClientSignerName,
+		Template: &x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName:   storagev1alpha1.VolumePoolCommonName(volumePoolName),
+				Organization: []string{storagev1alpha1.VolumePoolsGroup},
+			},
+		},
+		GetUsages: utilcertificate.DefaultKubeAPIServerClientGetUsages,
+	})
+}
+
+func NewGetterOrDie(volumePoolName string) *config.Getter {
+	getter, err := NewGetter(volumePoolName)
+	if err != nil {
+		log.Error(err, "Error creating getter")
+		os.Exit(1)
+	}
+	return getter
+}

--- a/utils/certificate/certificate.go
+++ b/utils/certificate/certificate.go
@@ -1,0 +1,311 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/certificate/csr"
+	"k8s.io/client-go/util/keyutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	kubeAPIServerClientUsagesWithEncipherment = []certificatesv1.KeyUsage{
+		// https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+		//
+		// Digital signature allows the certificate to be used to verify
+		// digital signatures used during TLS negotiation.
+		certificatesv1.UsageDigitalSignature,
+		// KeyEncipherment allows the cert/key pair to be used to encrypt
+		// keys, including the symmetric keys negotiated during TLS setup
+		// and used for data transfer.
+		certificatesv1.UsageKeyEncipherment,
+		// ClientAuth allows the cert to be used by a TLS client to
+		// authenticate itself to the TLS server.
+		certificatesv1.UsageClientAuth,
+	}
+	kubeAPIServerClientUsagesNoEncipherment = []certificatesv1.KeyUsage{
+		// https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+		//
+		// Digital signature allows the certificate to be used to verify
+		// digital signatures used during TLS negotiation.
+		certificatesv1.UsageDigitalSignature,
+		// ClientAuth allows the cert to be used by a TLS client to
+		// authenticate itself to the TLS server.
+		certificatesv1.UsageClientAuth,
+	}
+)
+
+func DefaultKubeAPIServerClientGetUsages(privateKey any) []certificatesv1.KeyUsage {
+	switch privateKey.(type) {
+	case *rsa.PrivateKey:
+		return kubeAPIServerClientUsagesWithEncipherment
+	default:
+		return kubeAPIServerClientUsagesNoEncipherment
+	}
+}
+
+func GenerateCertificateSigningRequestData(template *x509.CertificateRequest) (csrPEM, keyPEM []byte, key interface{}, err error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("error generating client certificate private key: %w", err)
+	}
+
+	der, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("error marshalling client certificate private key to DER: %w", err)
+	}
+
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: keyutil.ECPrivateKeyBlockType, Bytes: der})
+
+	csrPEM, err = certutil.MakeCSRFromTemplate(privateKey, template)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("error creating a csr using the certificate private key and template: %w", err)
+	}
+
+	return csrPEM, keyPEM, privateKey, nil
+}
+
+func MakeCertificatesCertificateSigningRequest(
+	signerName string,
+	csrPem []byte,
+	usages []certificatesv1.KeyUsage,
+	requestedDuration *time.Duration,
+) *certificatesv1.CertificateSigningRequest {
+	var expirationSeconds *int32
+	if requestedDuration != nil {
+		expirationSeconds = csr.DurationToExpirationSeconds(*requestedDuration)
+	}
+
+	return &certificatesv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "csr-",
+		},
+		Spec: certificatesv1.CertificateSigningRequestSpec{
+			Request:           csrPem,
+			Usages:            usages,
+			SignerName:        signerName,
+			ExpirationSeconds: expirationSeconds,
+		},
+	}
+}
+
+func createOrUseCSR(
+	ctx context.Context,
+	c client.Client,
+	csrObj *certificatesv1.CertificateSigningRequest,
+	privateKey any,
+) error {
+	newCSRObj := csrObj.DeepCopy()
+
+	if err := c.Create(ctx, csrObj); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("error creating certificate signing request: %w", err)
+		}
+
+		csrObjKey := client.ObjectKeyFromObject(csrObj)
+		if err := c.Get(ctx, csrObjKey, csrObj); err != nil {
+			return fmt.Errorf("error getting existing certificate signing request: %w", err)
+		}
+
+		if err := ensureCompatible(csrObj, newCSRObj, privateKey); err != nil {
+			return fmt.Errorf("existing certificate signing request is not compatible: %w", err)
+		}
+	}
+	return nil
+}
+
+func WaitForCertificate(ctx context.Context, c client.WithWatch, name string, uid types.UID) ([]byte, error) {
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", name).String()
+
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+			list := &certificatesv1.CertificateSigningRequestList{}
+			return list, c.List(ctx, list, &client.ListOptions{Raw: &options})
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+			return c.Watch(ctx, &certificatesv1.CertificateSigningRequestList{}, &client.ListOptions{Raw: &options})
+		},
+	}
+
+	var certData []byte
+	if _, err := watchtools.UntilWithSync(ctx, lw, &certificatesv1.CertificateSigningRequest{}, nil,
+		func(event watch.Event) (bool, error) {
+			switch event.Type {
+			case watch.Modified, watch.Added:
+			case watch.Deleted:
+				return false, fmt.Errorf("certificate signing request %q was deleted", name)
+			default:
+				return false, nil
+			}
+
+			csrObj, ok := event.Object.(*certificatesv1.CertificateSigningRequest)
+			if !ok {
+				return false, fmt.Errorf("unexpected type received: %T", event.Object)
+			}
+
+			if csrObj.UID != uid {
+				return false, fmt.Errorf("certificate signing request %q changed UIDs", name)
+			}
+
+			var approved bool
+			for _, c := range csrObj.Status.Conditions {
+				switch c.Type {
+				case certificatesv1.CertificateDenied:
+					return false, fmt.Errorf("certificate signing request is denied, reason: %v, message: %v", c.Reason, c.Message)
+				case certificatesv1.CertificateFailed:
+					return false, fmt.Errorf("certificate signing request failed, reason: %v, message: %v", c.Reason, c.Message)
+				case certificatesv1.CertificateApproved:
+					approved = true
+				}
+			}
+			if approved {
+				if csrCertData := csrObj.Status.Certificate; len(csrCertData) > 0 {
+					certData = csrCertData
+					return true, nil
+				}
+			}
+			return false, nil
+		},
+	); err != nil {
+		return nil, fmt.Errorf("error waiting for certificate: %w", err)
+	}
+	return certData, nil
+}
+
+func GenerateAndCreateCertificateSigningRequest(
+	ctx context.Context,
+	c client.Client,
+	signerName string,
+	template *x509.CertificateRequest,
+	getUsages func(privateKey any) []certificatesv1.KeyUsage,
+	requestedDuration *time.Duration,
+) (csrObj *certificatesv1.CertificateSigningRequest, keyPEM []byte, privateKey any, err error) {
+	if signerName == "" {
+		return nil, nil, nil, fmt.Errorf("must specify signerName")
+	}
+	if template == nil {
+		return nil, nil, nil, fmt.Errorf("must specify template")
+	}
+	if getUsages == nil {
+		return nil, nil, nil, fmt.Errorf("must specify getUsages")
+	}
+
+	csrPEM, keyPEM, privateKey, err := GenerateCertificateSigningRequestData(template)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("error generating csr data: %w", err)
+	}
+
+	usages := getUsages(privateKey)
+	csrObj = MakeCertificatesCertificateSigningRequest(signerName, csrPEM, usages, requestedDuration)
+
+	if err := createOrUseCSR(ctx, c, csrObj, privateKey); err != nil {
+		return nil, nil, nil, fmt.Errorf("error creating / using certificate signing request: %w", err)
+	}
+
+	return csrObj, keyPEM, privateKey, nil
+}
+
+func RequestCertificate(
+	ctx context.Context,
+	c client.WithWatch,
+	signerName string,
+	template *x509.CertificateRequest,
+	getUsages func(privateKey any) []certificatesv1.KeyUsage,
+	requestedDuration *time.Duration,
+) (*tls.Certificate, error) {
+	if signerName == "" {
+		return nil, fmt.Errorf("must specify signerName")
+	}
+	if template == nil {
+		return nil, fmt.Errorf("must specify template")
+	}
+	if getUsages == nil {
+		return nil, fmt.Errorf("must specify getUsages")
+	}
+
+	csrObj, keyPEM, _, err := GenerateAndCreateCertificateSigningRequest(ctx, c, signerName, template, getUsages, requestedDuration)
+	if err != nil {
+		return nil, err
+	}
+
+	certPEM, err := WaitForCertificate(ctx, c, csrObj.Name, csrObj.UID)
+	if err != nil {
+		return nil, fmt.Errorf("error waiting for certificate: %w", err)
+	}
+
+	newCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("error creating key pair: %w", err)
+	}
+
+	if err := setCertificateLeaf(&newCert); err != nil {
+		return nil, err
+	}
+	return &newCert, nil
+}
+
+func Marshal(cert *tls.Certificate) (certPEM, keyPEM []byte, err error) {
+	if len(cert.Certificate) == 0 {
+		return nil, nil, fmt.Errorf("no certificates in certificate chain")
+	}
+
+	var buf bytes.Buffer
+	for _, certDER := range cert.Certificate {
+		if err := pem.Encode(&buf, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: certDER,
+		}); err != nil {
+			return nil, nil, fmt.Errorf("error encodign certificate to pem: %w", err)
+		}
+	}
+
+	certPEM = buf.Bytes()
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error marshaling private key: %w", err)
+	}
+
+	keyPEM = pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyDER,
+	})
+
+	return certPEM, keyPEM, nil
+}

--- a/utils/certificate/certificate_suite_test.go
+++ b/utils/certificate/certificate_suite_test.go
@@ -1,0 +1,70 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const (
+	pollingInterval      = 50 * time.Millisecond
+	eventuallyTimeout    = 3 * time.Second
+	consistentlyDuration = 1 * time.Second
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
+
+func TestCertificate(t *testing.T) {
+	SetDefaultConsistentlyPollingInterval(pollingInterval)
+	SetDefaultEventuallyPollingInterval(pollingInterval)
+	SetDefaultEventuallyTimeout(eventuallyTimeout)
+	SetDefaultConsistentlyDuration(consistentlyDuration)
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Certificate Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	var err error
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{}
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(testEnv.Stop)
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	komega.SetClient(k8sClient)
+})

--- a/utils/certificate/rotator.go
+++ b/utils/certificate/rotator.go
@@ -1,0 +1,439 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"context"
+	"crypto"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/healthz"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	utilruntime.Must(certificatesv1.AddToScheme(scheme))
+}
+
+type rotator struct {
+	startedMu sync.Mutex
+	started   bool
+
+	name              string
+	newClient         func(cert *tls.Certificate) (client.WithWatch, error)
+	logConstructor    func() logr.Logger
+	signerName        string
+	template          *x509.CertificateRequest
+	getUsages         func(privateKey any) []certificatesv1.KeyUsage
+	requestedDuration *time.Duration
+	initContext       func(ctx context.Context) (context.Context, context.CancelFunc)
+
+	listenersMu sync.RWMutex
+	listeners   sets.Set[*handle]
+
+	forceInitial bool
+	certificate  atomic.Pointer[tls.Certificate]
+
+	queue workqueue.RateLimitingInterface
+}
+
+type Rotator interface {
+	manager.Runnable
+	healthz.HealthChecker
+	Init(ctx context.Context, force bool) error
+	Certificate() *tls.Certificate
+	AddListener(listener RotatorListener) RotatorListenerRegistration
+	RemoveListener(reg RotatorListenerRegistration)
+}
+
+type RotatorOptions struct {
+	Name              string
+	NewClient         func(cert *tls.Certificate) (client.WithWatch, error)
+	LogConstructor    func() logr.Logger
+	SignerName        string
+	Template          *x509.CertificateRequest
+	GetUsages         func(privateKey any) []certificatesv1.KeyUsage
+	RequestedDuration *time.Duration
+	ForceInitial      bool
+	InitCertificate   *tls.Certificate
+	InitContext       func(ctx context.Context) (context.Context, context.CancelFunc)
+}
+
+func ConstantLogger(logger logr.Logger) func() logr.Logger {
+	return func() logr.Logger {
+		return logger
+	}
+}
+
+func setRotatorOptionsDefaults(o *RotatorOptions) {
+	if o.LogConstructor == nil {
+		o.LogConstructor = func() logr.Logger {
+			return ctrl.Log.WithName(o.Name)
+		}
+	}
+	if o.InitContext == nil {
+		o.InitContext = func(ctx context.Context) (context.Context, context.CancelFunc) {
+			return context.WithTimeout(ctx, 30*time.Second)
+		}
+	}
+}
+
+func NewRotator(opts RotatorOptions) (Rotator, error) {
+	if opts.Name == "" {
+		return nil, fmt.Errorf("must specify Name")
+	}
+	if opts.NewClient == nil {
+		return nil, fmt.Errorf("must specify NewClient")
+	}
+	if opts.SignerName == "" {
+		return nil, fmt.Errorf("must specify SignerName")
+	}
+	if opts.Template == nil {
+		return nil, fmt.Errorf("must specify Template")
+	}
+	if opts.GetUsages == nil {
+		return nil, fmt.Errorf("must specify GetUsages")
+	}
+	setRotatorOptionsDefaults(&opts)
+
+	r := &rotator{
+		newClient:         opts.NewClient,
+		name:              opts.Name,
+		logConstructor:    opts.LogConstructor,
+		initContext:       opts.InitContext,
+		signerName:        opts.SignerName,
+		template:          opts.Template,
+		getUsages:         opts.GetUsages,
+		requestedDuration: opts.RequestedDuration,
+		forceInitial:      opts.ForceInitial,
+		listeners:         sets.New[*handle](),
+	}
+
+	if opts.InitCertificate != nil {
+		// Create shallow copy to safely mutate the leaf.
+		cert := *opts.InitCertificate
+		if err := setCertificateLeaf(&cert); err != nil {
+			return nil, fmt.Errorf("error setting certificate leaf: %w", err)
+		}
+
+		r.certificate.Store(&cert)
+	}
+
+	return r, nil
+}
+
+func TLSCertificateLeaf(cert *tls.Certificate) (*x509.Certificate, error) {
+	if cert.Leaf != nil {
+		return cert.Leaf, nil
+	}
+
+	if err := setCertificateLeaf(cert); err != nil {
+		return nil, err
+	}
+	return cert.Leaf, nil
+}
+
+// parseCSR extracts the CSR from the API object and decodes it.
+func parseCSR(pemData []byte) (*x509.CertificateRequest, error) {
+	// extract PEM from request object
+	block, _ := pem.Decode(pemData)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return nil, fmt.Errorf("PEM block type must be CERTIFICATE REQUEST")
+	}
+	return x509.ParseCertificateRequest(block.Bytes)
+}
+
+// ensureCompatible ensures that a CSR object is compatible with an original CSR
+func ensureCompatible(new, orig *certificatesv1.CertificateSigningRequest, privateKey interface{}) error {
+	newCSR, err := parseCSR(new.Spec.Request)
+	if err != nil {
+		return fmt.Errorf("unable to parse new csr: %v", err)
+	}
+	origCSR, err := parseCSR(orig.Spec.Request)
+	if err != nil {
+		return fmt.Errorf("unable to parse original csr: %v", err)
+	}
+	if !reflect.DeepEqual(newCSR.Subject, origCSR.Subject) {
+		return fmt.Errorf("csr subjects differ: new: %#v, orig: %#v", newCSR.Subject, origCSR.Subject)
+	}
+	if len(new.Spec.SignerName) > 0 && len(orig.Spec.SignerName) > 0 && new.Spec.SignerName != orig.Spec.SignerName {
+		return fmt.Errorf("csr signerNames differ: new %q, orig: %q", new.Spec.SignerName, orig.Spec.SignerName)
+	}
+	signer, ok := privateKey.(crypto.Signer)
+	if !ok {
+		return fmt.Errorf("privateKey is not a signer")
+	}
+	newCSR.PublicKey = signer.Public()
+	if err := newCSR.CheckSignature(); err != nil {
+		return fmt.Errorf("error validating signature new CSR against old key: %v", err)
+	}
+	if len(new.Status.Certificate) > 0 {
+		certs, err := certutil.ParseCertsPEM(new.Status.Certificate)
+		if err != nil {
+			return fmt.Errorf("error parsing signed certificate for CSR: %v", err)
+		}
+		now := time.Now()
+		for _, cert := range certs {
+			if now.After(cert.NotAfter) {
+				return fmt.Errorf("one of the certificates for the CSR has expired: %s", cert.NotAfter)
+			}
+		}
+	}
+	return nil
+}
+
+func (r *rotator) requestCertificate(ctx context.Context) (*tls.Certificate, error) {
+	c, err := r.newClient(r.certificate.Load())
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %w", err)
+	}
+
+	return RequestCertificate(ctx, c, r.signerName, r.template, r.getUsages, r.requestedDuration)
+}
+
+func setCertificateLeaf(cert *tls.Certificate) error {
+	if len(cert.Certificate) == 0 {
+		return fmt.Errorf("no certificates in certificate chain")
+	}
+
+	certs, err := x509.ParseCertificates(cert.Certificate[0])
+	if err != nil {
+		return fmt.Errorf("error parsing certificate data: %w", err)
+	}
+
+	cert.Leaf = certs[0]
+	return nil
+}
+
+func (r *rotator) nextRotationDeadline(force bool) time.Time {
+	if force {
+		return time.Now()
+	}
+
+	cert := r.certificate.Load()
+	if cert == nil {
+		return time.Now()
+	}
+
+	notAfter := cert.Leaf.NotAfter
+	totalDuration := float64(notAfter.Sub(cert.Leaf.NotBefore))
+	deadline := cert.Leaf.NotBefore.Add(jitteryDuration(totalDuration))
+	return deadline
+}
+
+func jitteryDuration(totalDuration float64) time.Duration {
+	return wait.Jitter(time.Duration(totalDuration), 0.2) - time.Duration(totalDuration*0.3)
+}
+
+func (r *rotator) getListeners() []RotatorListener {
+	r.listenersMu.RLock()
+	defer r.listenersMu.RUnlock()
+
+	res := make([]RotatorListener, 0, len(r.listeners))
+	for hdl := range r.listeners {
+		res = append(res, hdl.RotatorListener)
+	}
+	return res
+}
+
+func (r *rotator) rotate(ctx context.Context) error {
+	r.logConstructor().V(1).Info("Rotating certificate")
+	newCert, err := r.requestCertificate(ctx)
+	if err != nil {
+		return err
+	}
+
+	r.logConstructor().V(1).Info("Certificate rotated, storing updated certificate")
+	r.certificate.Store(newCert)
+
+	// Copy active listeners once to release lock as soon as possible.
+	listeners := r.getListeners()
+	r.logConstructor().V(1).Info("Notifying listeners")
+	for _, listener := range listeners {
+		listener.Enqueue()
+	}
+	return nil
+}
+
+func (r *rotator) enqueue(key interface{}) {
+	// If we want a forced initial rotation, respect it / reset it afterwards.
+	force := r.forceInitial
+	if force {
+		r.forceInitial = false
+	}
+
+	deadline := r.nextRotationDeadline(force)
+	if duration := time.Until(deadline); duration > 0 {
+		r.logConstructor().Info("Enqueuing for planned rotation", "Deadline", deadline, "Duration", duration)
+		r.queue.AddAfter(key, duration)
+	} else {
+		r.logConstructor().Info("Enqueueing for immediate rotation")
+		r.queue.Add(key)
+	}
+}
+
+func (r *rotator) processNextWorkItem(ctx context.Context) bool {
+	key, quit := r.queue.Get()
+	if quit {
+		return false
+	}
+	defer r.queue.Done(key)
+
+	if err := r.rotate(ctx); err != nil {
+		r.logConstructor().Error(err, "Error rotating certificate")
+		r.queue.AddRateLimited(key)
+		return true
+	}
+
+	r.queue.Forget(key)
+	r.enqueue(key)
+	return true
+}
+
+func (r *rotator) Certificate() *tls.Certificate {
+	return r.certificate.Load()
+}
+
+func (r *rotator) Init(ctx context.Context, force bool) error {
+	ctx, cancel := r.initContext(ctx)
+	defer cancel()
+
+	if time.Until(r.nextRotationDeadline(force)) <= 0 {
+		var lastErr error
+		if err := wait.PollImmediateInfiniteWithContext(ctx, 1*time.Second, func(ctx context.Context) (done bool, err error) {
+			lastErr = r.rotate(ctx)
+			if lastErr != nil {
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
+			return fmt.Errorf("error doing initial rotation: %w", lastErr)
+		}
+	}
+	return nil
+}
+
+const workItemKey = "key"
+
+func (r *rotator) Start(ctx context.Context) error {
+	r.startedMu.Lock()
+	if r.started {
+		r.startedMu.Unlock()
+		return fmt.Errorf("rotator was already started")
+	}
+
+	r.started = true
+	r.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	r.startedMu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for r.processNextWorkItem(ctx) {
+		}
+	}()
+
+	go func() {
+		defer r.queue.ShutDown()
+		<-ctx.Done()
+	}()
+
+	// Kick off initial enqueue
+	r.enqueue(workItemKey)
+
+	wg.Wait()
+	return nil
+}
+
+type RotatorListener interface {
+	Enqueue()
+}
+
+type RotatorListenerFunc func()
+
+func (f RotatorListenerFunc) Enqueue() {
+	f()
+}
+
+type RotatorListenerRegistration interface{}
+
+type handle struct {
+	RotatorListener
+}
+
+func (r *rotator) AddListener(listener RotatorListener) RotatorListenerRegistration {
+	r.listenersMu.Lock()
+	defer r.listenersMu.Unlock()
+
+	h := &handle{listener}
+	r.listeners.Insert(h)
+	return h
+}
+
+func (r *rotator) RemoveListener(reg RotatorListenerRegistration) {
+	r.listenersMu.Lock()
+	defer r.listenersMu.Unlock()
+
+	h, ok := reg.(*handle)
+	if !ok {
+		return
+	}
+
+	r.listeners.Delete(h)
+}
+
+func (r *rotator) Name() string {
+	return r.name
+}
+
+func (r *rotator) Check(_ *http.Request) error {
+	cert := r.Certificate()
+	if cert == nil {
+		return fmt.Errorf("certificate has not yet been issued")
+	}
+
+	leaf, err := TLSCertificateLeaf(cert)
+	if err != nil {
+		return fmt.Errorf("error getting certificate leaf: %w", err)
+	}
+
+	if time.Now().After(leaf.NotAfter) {
+		return fmt.Errorf("certificate is expired")
+	}
+	return nil
+}

--- a/utils/certificate/rotator_test.go
+++ b/utils/certificate/rotator_test.go
@@ -1,0 +1,148 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onmetal/onmetal-api/utils/certificate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Rotator", func() {
+	It("should rotate the certificates", func(ctx SpecContext) {
+		By("creating a new rotator")
+		signerName := "api.onmetal.de/test-signer"
+		r, err := NewRotator(RotatorOptions{
+			Name: "my-signer",
+			NewClient: func(cert *tls.Certificate) (client.WithWatch, error) {
+				return client.NewWithWatch(cfg, client.Options{})
+			},
+			SignerName:        signerName,
+			Template:          &x509.CertificateRequest{},
+			RequestedDuration: pointer.Duration(3 * time.Hour),
+			GetUsages: func(privateKey interface{}) []certificatesv1.KeyUsage {
+				return []certificatesv1.KeyUsage{
+					certificatesv1.UsageKeyEncipherment,
+				}
+			},
+			LogConstructor: ConstantLogger(GinkgoLogr.WithName("my-signer")),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var enqueueCt atomic.Int32
+		r.AddListener(RotatorListenerFunc(func() {
+			enqueueCt.Add(1)
+		}))
+
+		By("starting the rotator")
+		rotatorCtx, rotatorCancel := context.WithCancel(ctx)
+		defer rotatorCancel()
+		rotatorDone := make(chan struct{})
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(rotatorDone)
+			Expect(r.Start(rotatorCtx)).To(Succeed())
+		}()
+
+		By("waiting for the csr to be there")
+		csr := &certificatesv1.CertificateSigningRequest{}
+		Eventually(ctx, func(g Gomega) error {
+			csrList := &certificatesv1.CertificateSigningRequestList{}
+			Expect(k8sClient.List(ctx, csrList)).Should(Succeed())
+
+			for _, csrItem := range csrList.Items {
+				if csrItem.Spec.SignerName == signerName {
+					*csr = csrItem
+					return nil
+				}
+			}
+			return fmt.Errorf("no csr available for signer")
+		}).Should(Succeed())
+
+		By("parsing the certificate request")
+		block, _ := pem.Decode(csr.Spec.Request)
+		Expect(block).NotTo(BeNil())
+		Expect(block.Type).To(Equal("CERTIFICATE REQUEST"))
+		req, err := x509.ParseCertificateRequest(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("inspecting the certificate request")
+		Expect(req.CheckSignature()).To(Succeed())
+
+		By("manually approving the csr")
+		now := metav1.Now()
+		csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+			Type:               certificatesv1.CertificateApproved,
+			Status:             corev1.ConditionTrue,
+			Reason:             "AutoApproved",
+			Message:            "Approved for testing",
+			LastUpdateTime:     now,
+			LastTransitionTime: now,
+		})
+		Expect(k8sClient.SubResource("approval").Update(ctx, csr)).To(Succeed())
+
+		By("creating a self-signed ca")
+		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		Expect(err).NotTo(HaveOccurred())
+		caCert, err := certutil.NewSelfSignedCACert(certutil.Config{
+			CommonName:   "certificate-test",
+			Organization: []string{"certificate-test"},
+		}, privateKey)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a certificate from the request")
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, req.PublicKey, privateKey)
+		Expect(err).NotTo(HaveOccurred())
+		cert, err := x509.ParseCertificate(der)
+		Expect(err).NotTo(HaveOccurred())
+		certData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+		By("updating the csr status to have the certificate")
+		csr.Status.Certificate = certData
+		Expect(k8sClient.Status().Update(ctx, csr)).To(Succeed())
+
+		By("waiting for the rotator to report the certificate")
+		Eventually(ctx, r.Certificate).Should(HaveField("Leaf", Satisfy(cert.Equal)))
+
+		By("inspecting that the listener has been called")
+		Expect(enqueueCt.Load()).To(Equal(int32(1)))
+
+		By("stopping the rotator and waiting for it to shut down")
+		rotatorCancel()
+		Eventually(rotatorDone).Should(BeClosed())
+	})
+})

--- a/utils/certificate/testing/fake.go
+++ b/utils/certificate/testing/fake.go
@@ -1,0 +1,140 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/onmetal/onmetal-api/utils/certificate"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const FakeRotatorName = "fake-rotator"
+
+type FakeRotatorListenerHandle struct {
+	certificate.RotatorListener
+}
+
+type FakeRotator struct {
+	mu sync.RWMutex
+
+	started   bool
+	cert      *tls.Certificate
+	listeners sets.Set[*FakeRotatorListenerHandle]
+}
+
+func NewFakeRotator() *FakeRotator {
+	return &FakeRotator{
+		listeners: sets.New[*FakeRotatorListenerHandle](),
+	}
+}
+
+func (f *FakeRotator) Start(ctx context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.started {
+		return fmt.Errorf("rotator already started")
+	}
+	f.started = true
+	return nil
+}
+
+func (f *FakeRotator) Started() bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	return f.started
+}
+
+func (f *FakeRotator) Init(ctx context.Context, force bool) error {
+	return nil
+}
+
+func (f *FakeRotator) Certificate() *tls.Certificate {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.cert
+}
+
+func (f *FakeRotator) SetCertificate(cert *tls.Certificate) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cert = cert
+}
+
+func (f *FakeRotator) AddListener(listener certificate.RotatorListener) certificate.RotatorListenerRegistration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	handle := &FakeRotatorListenerHandle{listener}
+	f.listeners.Insert(handle)
+	return nil
+}
+
+func (f *FakeRotator) RemoveListener(reg certificate.RotatorListenerRegistration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	handle, ok := reg.(*FakeRotatorListenerHandle)
+	if !ok {
+		return
+	}
+	f.listeners.Delete(handle)
+}
+
+func (f *FakeRotator) Listeners() []certificate.RotatorListener {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	res := make([]certificate.RotatorListener, 0, len(f.listeners))
+	for handle := range f.listeners {
+		res = append(res, handle.RotatorListener)
+	}
+	return res
+}
+
+func (f *FakeRotator) EnqueueAll() {
+	listeners := f.Listeners()
+	for _, listener := range listeners {
+		listener.Enqueue()
+	}
+}
+
+func (f *FakeRotator) Name() string {
+	return FakeRotatorName
+}
+
+func (f *FakeRotator) Check(_ *http.Request) error {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	cert := f.cert
+	if cert == nil {
+		return fmt.Errorf("certificate has not yet been issued")
+	}
+
+	leaf, err := certificate.TLSCertificateLeaf(cert)
+	if err != nil {
+		return fmt.Errorf("error getting certificate leaf: %w", err)
+	}
+
+	if time.Now().After(leaf.NotAfter) {
+		return fmt.Errorf("certificate is expired")
+	}
+	return nil
+}

--- a/utils/client/config/config.go
+++ b/utils/client/config/config.go
@@ -1,0 +1,471 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	utilrest "github.com/onmetal/onmetal-api/utils/rest"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apiserver/pkg/server/egressselector"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// KubeconfigFlagName is the name of the kubeconfig flag.
+	KubeconfigFlagName = "kubeconfig"
+
+	// KubeconfigSecretNameFlagName is the name of the kubeconfig-secret-name flag.
+	KubeconfigSecretNameFlagName = "kubeconfig-secret-name"
+
+	// KubeconfigSecretNamespaceFlagName is the name of the kubeconfig-secret-namespace flag.
+	KubeconfigSecretNamespaceFlagName = "kubeconfig-secret-namespace"
+
+	// BootstrapKubeconfigFlagName is the name of the bootstrap-kubeconfig flag.
+	BootstrapKubeconfigFlagName = "bootstrap-kubeconfig"
+
+	// RotateFlagName is the name of the rotate flag.
+	RotateFlagName = "rotate"
+
+	// EgressSelectorConfigFlagName is the name of the egress-selector-config flag.
+	EgressSelectorConfigFlagName = "egress-selector-config"
+)
+
+var (
+	log = ctrl.Log.WithName("client").WithName("config")
+)
+
+// EgressSelectionName is the name of the egress configuration to use.
+type EgressSelectionName string
+
+const (
+	// EgressSelectionNameControlPlane instructs to use the controlplane egress selection.
+	EgressSelectionNameControlPlane EgressSelectionName = "controlplane"
+	// EgressSelectionNameEtcd instructs to use the etcd egress selection.
+	EgressSelectionNameEtcd EgressSelectionName = "etcd"
+	// EgressSelectionNameCluster instructs to use the cluster egress selection.
+	EgressSelectionNameCluster EgressSelectionName = "cluster"
+)
+
+// NetworkContext returns the corresponding network context of the egress selection.
+func (n EgressSelectionName) NetworkContext() (egressselector.NetworkContext, error) {
+	switch n {
+	case EgressSelectionNameControlPlane:
+		return egressselector.ControlPlane.AsNetworkContext(), nil
+	case EgressSelectionNameEtcd:
+		return egressselector.Etcd.AsNetworkContext(), nil
+	case EgressSelectionNameCluster:
+		return egressselector.Cluster.AsNetworkContext(), nil
+	default:
+		return egressselector.NetworkContext{}, fmt.Errorf("unknown egress selection name %q", n)
+	}
+}
+
+func setGetConfigOptionsDefaults(o *GetConfigOptions) {
+	if o.EgressSelectionName == "" {
+		o.EgressSelectionName = EgressSelectionNameControlPlane
+	}
+}
+
+type NewControllerFunc func(ctx context.Context, store Store, bootstrapCfg *rest.Config, opts ControllerOptions) (Controller, error)
+
+type GetterOptions struct {
+	Name              string
+	SignerName        string
+	Template          *x509.CertificateRequest
+	GetUsages         func(privateKey any) []certificatesv1.KeyUsage
+	RequestedDuration *time.Duration
+	LogConstructor    func() logr.Logger
+	NewController     NewControllerFunc
+	ForceInitial      bool
+}
+
+func setGetterOptionsDefaults(o *GetterOptions) {
+	if o.LogConstructor == nil {
+		log := ctrl.Log.WithName("client").WithName("config").WithValues("getter", o.Name)
+		o.LogConstructor = func() logr.Logger {
+			return log
+		}
+	}
+	if o.NewController == nil {
+		o.NewController = NewController
+	}
+}
+
+type Getter struct {
+	name              string
+	signerName        string
+	template          *x509.CertificateRequest
+	getUsages         func(privateKey any) []certificatesv1.KeyUsage
+	requestedDuration *time.Duration
+	logConstructor    func() logr.Logger
+	newController     NewControllerFunc
+	forceInitial      bool
+}
+
+func NewGetter(opts GetterOptions) (*Getter, error) {
+	if opts.Name == "" {
+		return nil, fmt.Errorf("must specify Name")
+	}
+	if opts.SignerName == "" {
+		return nil, fmt.Errorf("must specify SignerName")
+	}
+	if opts.Template == nil {
+		return nil, fmt.Errorf("must specify Template")
+	}
+	if opts.GetUsages == nil {
+		return nil, fmt.Errorf("must specify GetUsages")
+	}
+	setGetterOptionsDefaults(&opts)
+
+	return &Getter{
+		name:              opts.Name,
+		signerName:        opts.SignerName,
+		template:          opts.Template,
+		getUsages:         opts.GetUsages,
+		requestedDuration: opts.RequestedDuration,
+		logConstructor:    opts.LogConstructor,
+		newController:     opts.NewController,
+		forceInitial:      opts.ForceInitial,
+	}, nil
+}
+
+func NewGetterOrDie(opts GetterOptions) *Getter {
+	getter, err := NewGetter(opts)
+	if err != nil {
+		log.Error(err, "unable to create getter")
+		os.Exit(1)
+	}
+	return getter
+}
+
+func StoreFromOptions(o *GetConfigOptions) (Store, error) {
+	switch {
+	case o.Kubeconfig != "" && o.KubeconfigSecretName != "":
+		return nil, fmt.Errorf("cannot specify both kubeconfig and kubeconfig-secret-name")
+	case o.Kubeconfig != "":
+		return FileStore(o.Kubeconfig), nil
+	case o.KubeconfigSecretName != "":
+		namespace := o.KubeconfigSecretNamespace
+		if namespace == "" {
+			namespace = LoadDefaultNamespace()
+		}
+
+		defaultCfg, err := LoadDefaultConfig("")
+		if err != nil {
+			return nil, fmt.Errorf("error loading default config: %w", err)
+		}
+
+		c, err := client.New(defaultCfg, client.Options{})
+		if err != nil {
+			return nil, fmt.Errorf("error creating client: %w", err)
+		}
+
+		key := client.ObjectKey{Namespace: namespace, Name: o.KubeconfigSecretName}
+		return NewSecretStore(c, key, &SecretStoreOptions{
+			Field: o.KubeconfigSecretField,
+		}), nil
+	default:
+		return nil, nil
+	}
+}
+
+func LoaderFromOptions(o *GetConfigOptions) (Loader, error) {
+	switch {
+	case o.Kubeconfig != "" && o.KubeconfigSecretName != "":
+		return nil, fmt.Errorf("cannot specify both kubeconfig and kubeconfig-secret-name")
+	case o.Kubeconfig != "":
+		return FileLoader(o.Kubeconfig), nil
+	case o.KubeconfigSecretName != "":
+		namespace := o.KubeconfigSecretNamespace
+		if namespace == "" {
+			namespace = LoadDefaultNamespace()
+		}
+
+		defaultCfg, err := LoadDefaultConfig("")
+		if err != nil {
+			return nil, fmt.Errorf("error loading default config: %w", err)
+		}
+
+		c, err := client.New(defaultCfg, client.Options{})
+		if err != nil {
+			return nil, fmt.Errorf("error creating client: %w", err)
+		}
+
+		key := client.ObjectKey{Namespace: namespace, Name: o.KubeconfigSecretName}
+		return NewSecretLoader(c, key, &SecretLoaderOptions{
+			Field: o.KubeconfigSecretField,
+		}), nil
+	default:
+		return nil, nil
+	}
+}
+
+// GetConfig creates a *rest.Config for talking to a Kubernetes API server.
+// Kubeconfig / the '--kubeconfig' flag instruct to use the kubeconfig file at that location.
+// Otherwise, will assume running in cluster and use the cluster provided kubeconfig.
+//
+// It also applies saner defaults for QPS and burst based on the Kubernetes
+// controller manager defaults (20 QPS, 30 burst)
+//
+// # Config precedence
+//
+// * Kubeconfig / --kubeconfig value / flag pointing at a file
+//
+// * KUBECONFIG environment variable pointing at a file
+//
+// * In-cluster config if running in cluster
+//
+// * $HOME/.kube/config if exists.
+func (g *Getter) GetConfig(ctx context.Context, opts ...GetConfigOption) (*rest.Config, Controller, error) {
+	o := &GetConfigOptions{}
+	o.ApplyOptions(opts)
+	setGetConfigOptionsDefaults(o)
+
+	if o.Kubeconfig != "" && o.KubeconfigSecretName != "" {
+		return nil, nil, fmt.Errorf("cannot specify kubeconfig and kubeconfig-secret-name")
+	}
+
+	switch {
+	case o.Rotate:
+		g.logConstructor().Info("Getting config and initializing rotation")
+		return g.getConfigAndController(ctx, o)
+	case o.BootstrapKubeconfig != "":
+		g.logConstructor().Info("Getting / bootstrapping config if necessary")
+		return g.getAndBootstrapConfigIfNecessary(ctx, o)
+	default:
+		g.logConstructor().Info("Getting config")
+		return g.getConfig(ctx, o)
+	}
+}
+
+func (g *Getter) getConfig(ctx context.Context, o *GetConfigOptions) (*rest.Config, Controller, error) {
+	loader, err := LoaderFromOptions(o)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting loader: %w", err)
+	}
+
+	var cfg *rest.Config
+	if loader != nil {
+		cfg, err = loader.Load(ctx, &clientcmd.ConfigOverrides{
+			CurrentContext: o.Context,
+		})
+	} else {
+		cfg, err = LoadDefaultConfig(o.Context)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dialFunc, err := GetEgressSelectorDial(o.EgressSelectorConfig, o.EgressSelectionName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cfg.Dial = dialFunc
+	return cfg, nil, nil
+}
+
+func (g *Getter) getAndBootstrapConfigIfNecessary(ctx context.Context, o *GetConfigOptions) (*rest.Config, Controller, error) {
+	store, err := StoreFromOptions(o)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting store: %w", err)
+	}
+	if store == nil {
+		return nil, nil, fmt.Errorf("must specify either kubeconfig or kubeconfig-secret-name when bootstrap is enabled")
+	}
+
+	cfg, err := store.Get(ctx)
+	if IgnoreErrConfigNotFound(err) != nil {
+		return nil, nil, fmt.Errorf("error getting kubeconfig: %w", err)
+	}
+
+	bootstrapCfg, err := FileLoader(o.BootstrapKubeconfig).Load(ctx, nil)
+	if IgnoreErrConfigNotFound(err) != nil {
+		return nil, nil, fmt.Errorf("error loading bootstrap kubeconfig: %w", err)
+	}
+
+	if cfg == nil && bootstrapCfg == nil {
+		return nil, nil, fmt.Errorf("must specify either valid kubeconfig or bootstrap-kubeconfig")
+	}
+
+	cfg, newCfg, err := utilrest.UseOrRequestConfig(ctx, cfg, bootstrapCfg, g.signerName, g.template, g.getUsages, g.requestedDuration)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error using / requesting config: %w", err)
+	}
+	if newCfg {
+		if err := store.Set(ctx, cfg); err != nil {
+			return nil, nil, fmt.Errorf("error persisting new config: %w", err)
+		}
+	}
+
+	dialFunc, err := GetEgressSelectorDial(o.EgressSelectorConfig, o.EgressSelectionName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cfg.Dial = dialFunc
+	return cfg, nil, nil
+}
+
+func (g *Getter) getConfigAndController(ctx context.Context, o *GetConfigOptions) (*rest.Config, Controller, error) {
+	store, err := StoreFromOptions(o)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting store: %w", err)
+	}
+	if store == nil {
+		return nil, nil, fmt.Errorf("must specify either kubeconfig or kubeconfig-secret-name when rotate is enabled")
+	}
+
+	dialFunc, err := GetEgressSelectorDial(o.EgressSelectorConfig, o.EgressSelectionName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bootstrapCfg, err := FileLoader(o.BootstrapKubeconfig).Load(ctx, nil)
+	if IgnoreErrConfigNotFound(err) != nil {
+		return nil, nil, fmt.Errorf("error loading bootstrap kubeconfig: %w", err)
+	}
+
+	c, err := g.newController(ctx, store, bootstrapCfg, ControllerOptions{
+		Name:              g.name,
+		SignerName:        g.signerName,
+		Template:          g.template,
+		GetUsages:         g.getUsages,
+		RequestedDuration: g.requestedDuration,
+		LogConstructor: func() logr.Logger {
+			return g.logConstructor().WithValues("controller", g.name)
+		},
+		DialFunc:     dialFunc,
+		ForceInitial: g.forceInitial,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating rotator: %w", err)
+	}
+	if err := c.Init(ctx, false); err != nil {
+		return nil, nil, fmt.Errorf("error running rotator once: %w", err)
+	}
+	return c.TransportConfig(), c, nil
+}
+
+func LoadDefaultNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+
+	// Fall back to the namespace associated with the service account token, if available
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
+			return ns
+		}
+	}
+
+	return corev1.NamespaceDefault
+}
+
+func loadConfigWithContext(apiServerURL string, loader clientcmd.ClientConfigLoader, context string) (*rest.Config, error) {
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loader,
+		&clientcmd.ConfigOverrides{
+			ClusterInfo: clientcmdapi.Cluster{
+				Server: apiServerURL,
+			},
+			CurrentContext: context,
+		}).ClientConfig()
+}
+
+func LoadDefaultConfig(context string) (*rest.Config, error) {
+	// If the recommended kubeconfig env variable is not specified,
+	// try the in-cluster config.
+	kubeconfigPath := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
+	if len(kubeconfigPath) == 0 {
+		if c, err := rest.InClusterConfig(); err == nil {
+			return c, nil
+		}
+	}
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if _, ok := os.LookupEnv("HOME"); !ok {
+		u, err := user.Current()
+		if err != nil {
+			return nil, fmt.Errorf("could not get current user: %v", err)
+		}
+		loadingRules.Precedence = append(
+			loadingRules.Precedence,
+			filepath.Join(u.HomeDir, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName),
+		)
+	}
+
+	return loadConfigWithContext("", loadingRules, context)
+}
+
+func GetEgressSelectorDial(egressSelectorConfig string, egressSelectionName EgressSelectionName) (utilnet.DialFunc, error) {
+	if egressSelectorConfig == "" {
+		return nil, nil
+	}
+
+	networkContext, err := egressSelectionName.NetworkContext()
+	if err != nil {
+		return nil, fmt.Errorf("error obtaining network context: %w", err)
+	}
+
+	egressSelectorCfg, err := egressselector.ReadEgressSelectorConfiguration(egressSelectorConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error reading egress selector configuration: %w", err)
+	}
+
+	egressSelector, err := egressselector.NewEgressSelector(egressSelectorCfg)
+	if err != nil {
+		return nil, fmt.Errorf("error creating egress selector: %w", err)
+	}
+
+	dial, err := egressSelector.Lookup(networkContext)
+	if err != nil {
+		return nil, fmt.Errorf("error looking up network context %s: %w", networkContext.EgressSelectionName.String(), err)
+	}
+	if dial == nil {
+		return nil, fmt.Errorf("no dialer for network context %s", networkContext.EgressSelectionName.String())
+	}
+
+	return dial, nil
+}
+
+// GetConfigOrDie creates a *rest.Config for talking to a Kubernetes apiserver.
+// If Kubeconfig / --kubeconfig is set, will use the kubeconfig file at that location. Otherwise, will assume running
+// in cluster and use the cluster provided kubeconfig.
+//
+// Will log an error and exit if there is an error creating the rest.Config.
+func (g *Getter) GetConfigOrDie(ctx context.Context, opts ...GetConfigOption) (*rest.Config, Controller) {
+	config, rotator, err := g.GetConfig(ctx, opts...)
+	if err != nil {
+		log.Error(err, "unable to get kubeconfig")
+		os.Exit(1)
+	}
+	return config, rotator
+}

--- a/utils/client/config/config_suite_test.go
+++ b/utils/client/config/config_suite_test.go
@@ -1,0 +1,70 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const (
+	pollingInterval      = 50 * time.Millisecond
+	eventuallyTimeout    = 3 * time.Second
+	consistentlyDuration = 1 * time.Second
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
+
+func TestConfig(t *testing.T) {
+	SetDefaultConsistentlyPollingInterval(pollingInterval)
+	SetDefaultEventuallyPollingInterval(pollingInterval)
+	SetDefaultEventuallyTimeout(eventuallyTimeout)
+	SetDefaultConsistentlyDuration(consistentlyDuration)
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Config Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	var err error
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{}
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(testEnv.Stop)
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	komega.SetClient(k8sClient)
+})

--- a/utils/client/config/controller.go
+++ b/utils/client/config/controller.go
@@ -1,0 +1,244 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/onmetal/onmetal-api/utils/certificate"
+	utilrest "github.com/onmetal/onmetal-api/utils/rest"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apiserver/pkg/server/healthz"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type Controller interface {
+	manager.Runnable
+	healthz.HealthChecker
+	Init(ctx context.Context, force bool) error
+	TransportConfig() *rest.Config
+	ClientConfig() *rest.Config
+}
+
+type NewRESTConfigRotatorFunc func(cfg, bootstrapCfg *rest.Config, opts utilrest.ConfigRotatorOptions) (utilrest.ConfigRotator, error)
+
+type ControllerOptions struct {
+	Name                 string
+	SignerName           string
+	Template             *x509.CertificateRequest
+	GetUsages            func(privateKey any) []certificatesv1.KeyUsage
+	RequestedDuration    *time.Duration
+	LogConstructor       func() logr.Logger
+	DialFunc             utilnet.DialFunc
+	ForceInitial         bool
+	NewRESTConfigRotator NewRESTConfigRotatorFunc
+}
+
+func setControllerOptionsDefaults(o *ControllerOptions) {
+	if o.LogConstructor == nil {
+		log := ctrl.Log.WithName("client").WithName("config").WithValues("controller", o.Name)
+		o.LogConstructor = func() logr.Logger {
+			return log
+		}
+	}
+	if o.NewRESTConfigRotator == nil {
+		o.NewRESTConfigRotator = utilrest.NewConfigRotator
+	}
+}
+
+type controller struct {
+	startedMu sync.Mutex
+	started   bool
+
+	name           string
+	logConstructor func() logr.Logger
+	store          Store
+
+	queue workqueue.RateLimitingInterface
+
+	configRotator utilrest.ConfigRotator
+}
+
+func NewController(ctx context.Context, store Store, bootstrapCfg *rest.Config, opts ControllerOptions) (Controller, error) {
+	if opts.Name == "" {
+		return nil, fmt.Errorf("must specify Name")
+	}
+	if opts.SignerName == "" {
+		return nil, fmt.Errorf("must specify SignerName")
+	}
+	if opts.Template == nil {
+		return nil, fmt.Errorf("must specify Template")
+	}
+	if opts.GetUsages == nil {
+		return nil, fmt.Errorf("must specify GetUsages")
+	}
+	setControllerOptionsDefaults(&opts)
+
+	cfg, err := store.Get(ctx)
+	if IgnoreErrConfigNotFound(err) != nil {
+		return nil, fmt.Errorf("error getting config from store: %w", err)
+	}
+
+	configRotator, err := opts.NewRESTConfigRotator(cfg, bootstrapCfg, utilrest.ConfigRotatorOptions{
+		Name:              opts.Name,
+		SignerName:        opts.SignerName,
+		Template:          opts.Template,
+		GetUsages:         opts.GetUsages,
+		RequestedDuration: opts.RequestedDuration,
+		LogConstructor: func() logr.Logger {
+			return opts.LogConstructor().WithName("rest").WithValues("configrotator", opts.Name)
+		},
+		DialFunc:     opts.DialFunc,
+		ForceInitial: opts.ForceInitial,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating rotator: %w", err)
+	}
+
+	return &controller{
+		name:           opts.Name,
+		logConstructor: opts.LogConstructor,
+		store:          store,
+		configRotator:  configRotator,
+	}, nil
+}
+
+const workItemKey = "key"
+
+func (c *controller) persist(ctx context.Context) error {
+	clientConfig := c.configRotator.ClientConfig()
+	if clientConfig == nil {
+		return fmt.Errorf("no client config available")
+	}
+
+	if err := c.store.Set(ctx, clientConfig); err != nil {
+		return fmt.Errorf("error persisting client config: %w", err)
+	}
+	return nil
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	item, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(item)
+
+	if err := c.persist(ctx); err != nil {
+		c.logConstructor().Error(err, "Error persisting")
+		c.queue.AddRateLimited(item)
+		return true
+	}
+
+	c.queue.Forget(item)
+	return true
+}
+
+func (c *controller) TransportConfig() *rest.Config {
+	return c.configRotator.TransportConfig()
+}
+
+func (c *controller) ClientConfig() *rest.Config {
+	return c.configRotator.ClientConfig()
+}
+
+func (c *controller) Name() string {
+	return c.name
+}
+
+func (c *controller) Check(req *http.Request) error {
+	return c.configRotator.Check(req)
+}
+
+func (c *controller) Init(ctx context.Context, force bool) error {
+	if err := c.configRotator.Init(ctx, force); err != nil {
+		return fmt.Errorf("error running config rotator: %w", err)
+	}
+	if err := c.persist(ctx); err != nil {
+		return fmt.Errorf("error persisting: %w", err)
+	}
+	return nil
+}
+
+func (c *controller) Start(ctx context.Context) error {
+	c.startedMu.Lock()
+	if c.started {
+		c.startedMu.Unlock()
+		return fmt.Errorf("controller was already started")
+	}
+
+	c.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	go func() {
+		<-ctx.Done()
+		c.queue.ShutDown()
+	}()
+
+	reg := c.configRotator.AddListener(certificate.RotatorListenerFunc(func() {
+		c.queue.Add(workItemKey)
+	}))
+	defer c.configRotator.RemoveListener(reg)
+
+	var wg sync.WaitGroup
+
+	if err := func() error {
+		defer c.startedMu.Unlock()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = c.configRotator.Start(ctx)
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for c.processNextWorkItem(ctx) {
+			}
+		}()
+
+		c.started = true
+		return nil
+	}(); err != nil {
+		return err
+	}
+
+	<-ctx.Done()
+	wg.Wait()
+	return nil
+}
+
+func SetupControllerWithManager(mgr ctrl.Manager, c Controller) error {
+	if c == nil {
+		return nil
+	}
+
+	if err := mgr.Add(c); err != nil {
+		return fmt.Errorf("error adding config controller to manager: %w", err)
+	}
+	if err := mgr.AddHealthzCheck(c.Name(), c.Check); err != nil {
+		return fmt.Errorf("error adding config controller healthz check: %w", err)
+	}
+	return nil
+}

--- a/utils/client/config/controller_test.go
+++ b/utils/client/config/controller_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"context"
+	"crypto/x509"
+
+	"github.com/go-logr/logr"
+	utilcertificate "github.com/onmetal/onmetal-api/utils/certificate"
+	"github.com/onmetal/onmetal-api/utils/client/config"
+	utilrest "github.com/onmetal/onmetal-api/utils/rest"
+	utilresttesting "github.com/onmetal/onmetal-api/utils/rest/testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+)
+
+var _ = Describe("Controller", func() {
+	It("should persist the config", func(ctx SpecContext) {
+		By("creating a fake config rotator")
+		restConfigRotator := utilresttesting.NewFakeConfigRotator()
+
+		By("creating a file-based store")
+		store := new(config.MemoryStore)
+
+		By("creating a controller")
+		bootstrapCfg := &rest.Config{
+			Host: "https://k8s.example.org",
+		}
+		c, err := config.NewController(ctx, store, bootstrapCfg, config.ControllerOptions{
+			Name:           "sample-controller",
+			SignerName:     "sample-signer",
+			Template:       &x509.CertificateRequest{},
+			GetUsages:      utilcertificate.DefaultKubeAPIServerClientGetUsages,
+			LogConstructor: func() logr.Logger { return GinkgoLogr },
+			NewRESTConfigRotator: func(cfg, bootstrapCfg *rest.Config, opts utilrest.ConfigRotatorOptions) (utilrest.ConfigRotator, error) {
+				return restConfigRotator, nil
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("starting the controller")
+		ctrlErr := make(chan error, 1)
+		ctrlCtx, cancelCtrl := context.WithCancel(ctx)
+		defer cancelCtrl()
+		go func() {
+			ctrlErr <- c.Start(ctrlCtx)
+		}()
+
+		By("waiting for the rest config rotator to be started")
+		Eventually(ctx, restConfigRotator.Started).Should(BeTrue(), "rest config rotator was not started")
+
+		By("asserting no client config becomes available and stored")
+		Consistently(ctx, func(g Gomega) {
+			g.Expect(c.ClientConfig()).To(BeNil())
+			_, err := store.Get(ctx)
+			g.Expect(err).To(MatchError(config.ErrConfigNotFound))
+			g.Expect(c.Check(nil)).To(HaveOccurred())
+		}).Should(Succeed())
+
+		By("supplying a client config and enqueuing all listeners")
+		authCfg := &rest.Config{
+			Host:     "https://k8s.example.org",
+			Username: "foo",
+			Password: "bar",
+		}
+		restConfigRotator.SetClientConfig(authCfg)
+		restConfigRotator.EnqueueAll()
+
+		By("waiting for the client config to be available and stored")
+		Eventually(ctx, func(g Gomega) {
+			g.Expect(c.ClientConfig()).To(Equal(authCfg))
+			g.Expect(store.Get(ctx)).To(Equal(authCfg))
+		}).Should(Succeed())
+
+		By("stopping the controller and waiting for it to return")
+		cancelCtrl()
+		Eventually(ctx, ctrlErr).Should(Receive(BeNil()))
+	})
+})

--- a/utils/client/config/errors.go
+++ b/utils/client/config/errors.go
@@ -1,0 +1,26 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "errors"
+
+var ErrConfigNotFound = errors.New("config not found")
+
+func IgnoreErrConfigNotFound(err error) error {
+	if errors.Is(err, ErrConfigNotFound) {
+		return nil
+	}
+	return err
+}

--- a/utils/client/config/loader.go
+++ b/utils/client/config/loader.go
@@ -1,0 +1,112 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Loader interface {
+	Load(ctx context.Context, overrides *clientcmd.ConfigOverrides) (*rest.Config, error)
+}
+
+type FileLoader string
+
+func (l FileLoader) Load(ctx context.Context, overrides *clientcmd.ConfigOverrides) (*rest.Config, error) {
+	apiCfg, err := clientcmd.LoadFromFile(string(l))
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("error loading api config from file: %w", err)
+		}
+		return nil, ErrConfigNotFound
+	}
+
+	return clientcmd.NewDefaultClientConfig(*apiCfg, overrides).ClientConfig()
+}
+
+type SecretLoader struct {
+	rd    client.Reader
+	key   client.ObjectKey
+	field string
+}
+
+type SecretLoaderOptions struct {
+	Field string
+}
+
+func (o *SecretLoaderOptions) ApplyOptions(opts []SecretLoaderOption) {
+	for _, opt := range opts {
+		opt.ApplyToSecretLoader(o)
+	}
+}
+
+func (o *SecretLoaderOptions) ApplyToSecretLoader(o2 *SecretLoaderOptions) {
+	if o.Field != "" {
+		o2.Field = o.Field
+	}
+}
+
+type SecretLoaderOption interface {
+	ApplyToSecretLoader(o *SecretLoaderOptions)
+}
+
+func setSecretLoaderOptionsDefaults(o *SecretLoaderOptions) {
+	if o.Field == "" {
+		o.Field = DefaultSecretKubeconfigField
+	}
+}
+
+func NewSecretLoader(rd client.Reader, key client.ObjectKey, opts ...SecretLoaderOption) *SecretLoader {
+	o := &SecretLoaderOptions{}
+	o.ApplyOptions(opts)
+	setSecretLoaderOptionsDefaults(o)
+
+	return &SecretLoader{
+		rd:    rd,
+		key:   key,
+		field: o.Field,
+	}
+}
+
+func (l *SecretLoader) Load(ctx context.Context, overrides *clientcmd.ConfigOverrides) (*rest.Config, error) {
+	secret := &corev1.Secret{}
+	if err := l.rd.Get(ctx, l.key, secret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("error getting secret %s: %w", l.key, err)
+		}
+		return nil, ErrConfigNotFound
+	}
+
+	data, ok := secret.Data[l.field]
+	if !ok || len(data) == 0 {
+		return nil, ErrConfigNotFound
+	}
+
+	apiCfg, err := clientcmd.Load(data)
+	if err != nil {
+		return nil, fmt.Errorf("error loading api config from secret data: %w", err)
+	}
+
+	return clientcmd.NewDefaultClientConfig(*apiCfg, overrides).ClientConfig()
+}

--- a/utils/client/config/loader_test.go
+++ b/utils/client/config/loader_test.go
@@ -1,0 +1,151 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"os"
+
+	"github.com/onmetal/onmetal-api/utils/client/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Loader", func() {
+	var (
+		apiCfg     *clientcmdapi.Config
+		apiCfgData []byte
+	)
+	BeforeEach(func() {
+		apiCfg = &clientcmdapi.Config{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"default": {
+					Server: "https://foo.example.org",
+				},
+			},
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{
+				"default": {
+					Username: "foo",
+					Password: "bar",
+				},
+			},
+			Contexts: map[string]*clientcmdapi.Context{
+				"default": {
+					Cluster:  "default",
+					AuthInfo: "default",
+				},
+			},
+			CurrentContext: "default",
+		}
+		var err error
+		apiCfgData, err = clientcmd.Write(*apiCfg)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("FileLoader", func() {
+		var (
+			existingFile    string
+			nonExistentFile string
+		)
+		BeforeEach(func() {
+			tmpFile, err := os.CreateTemp(GinkgoT().TempDir(), "kubeconfig")
+			Expect(err).NotTo(HaveOccurred())
+			existingFile = tmpFile.Name()
+			Expect(tmpFile.Close()).To(Succeed())
+
+			Expect(clientcmd.WriteToFile(*apiCfg, existingFile)).To(Succeed())
+
+			nonExistentFile = "/definitely/should/never/exist"
+		})
+
+		Describe("Load", func() {
+			It("should load the config from file", func(ctx SpecContext) {
+				cfg, err := config.FileLoader(existingFile).Load(ctx, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).To(Equal(&rest.Config{
+					Host:     "https://foo.example.org",
+					Username: "foo",
+					Password: "bar",
+				}))
+			})
+
+			It("should return ErrConfigNotFound if a config does not exist", func(ctx SpecContext) {
+				_, err := config.FileLoader(nonExistentFile).Load(ctx, nil)
+				Expect(err).To(MatchError(config.ErrConfigNotFound))
+			})
+		})
+	})
+
+	Context("SecretLoader", func() {
+		var (
+			existingSecretKey    client.ObjectKey
+			nonExistentSecretKey client.ObjectKey
+			ns                   *corev1.Namespace
+		)
+		BeforeEach(func(ctx SpecContext) {
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "ns-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, ns)
+
+			existingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    ns.Name,
+					GenerateName: "kubeconfig-",
+				},
+				Data: map[string][]byte{
+					config.DefaultSecretKubeconfigField: apiCfgData,
+				},
+			}
+			Expect(k8sClient.Create(ctx, existingSecret)).To(Succeed())
+
+			existingSecretKey = client.ObjectKeyFromObject(existingSecret)
+			nonExistentSecretKey = client.ObjectKey{Namespace: ns.Name, Name: "should-definitely-not-exist"}
+		})
+
+		Describe("Load", func() {
+			It("should load the config from the secret", func(ctx SpecContext) {
+				ld := config.NewSecretLoader(k8sClient, existingSecretKey)
+				cfg, err := ld.Load(ctx, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).To(Equal(&rest.Config{
+					Host:     "https://foo.example.org",
+					Username: "foo",
+					Password: "bar",
+				}))
+			})
+
+			It("should return ErrConfigNotFound if the secret does not exist", func(ctx SpecContext) {
+				ld := config.NewSecretLoader(k8sClient, nonExistentSecretKey)
+				_, err := ld.Load(ctx, nil)
+				Expect(err).To(MatchError(config.ErrConfigNotFound))
+			})
+
+			It("should return ErrConfigNotFound if there is no data at the secret field", func(ctx SpecContext) {
+				ld := config.NewSecretLoader(k8sClient, existingSecretKey, config.WithField("other-field"))
+				_, err := ld.Load(ctx, nil)
+				Expect(err).To(MatchError(config.ErrConfigNotFound))
+			})
+		})
+	})
+})

--- a/utils/client/config/options.go
+++ b/utils/client/config/options.go
@@ -1,0 +1,132 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// GetConfigOptions are options to supply for a GetConfig call.
+type GetConfigOptions struct {
+	// Context is the kubeconfig context to load.
+	Context string
+
+	// Kubeconfig specifies where to get the kubeconfig from.
+	Kubeconfig string
+
+	// KubeconfigSecretName instructs to get the kubeconfig from a secret with the given name.
+	KubeconfigSecretName string
+
+	// KubeconfigSecretNamespace instructs to get the kubeconfig from a secret within the given namespace.
+	// If unset, LoadDefaultNamespace will be used to determine the namespace.
+	KubeconfigSecretNamespace string
+
+	// KubeconfigSecretField specifies the field of the secret to get the kubeconfig from.
+	// If unset, DefaultSecretKubeconfigField will be used.
+	KubeconfigSecretField string
+
+	// BootstrapKubeconfig specifies the path to the bootstrap kubeconfig to load.
+	// The bootstrap kubeconfig will be used to request an up-to-date certificate for the kube-apiserver.
+	BootstrapKubeconfig string
+
+	// Rotate specifies whether kubeconfig should be automatically rotated.
+	Rotate bool
+
+	// EgressSelectorConfig is the path to an egress selector config to load.
+	EgressSelectorConfig string
+	// EgressSelectionName is the name of the egress configuration to use.
+	// Defaults to EgressSelectionNameControlPlane.
+	EgressSelectionName EgressSelectionName
+}
+
+func (o *GetConfigOptions) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.Kubeconfig, KubeconfigFlagName, "", "Paths to a kubeconfig. Only required if out-of-cluster.")
+	fs.StringVar(&o.KubeconfigSecretName, KubeconfigSecretNameFlagName, "", "Name of a kubeconfig secret to use.")
+	fs.StringVar(&o.KubeconfigSecretNamespace, KubeconfigSecretNamespaceFlagName, "", "Namespace of the kubeconfig secret to use. If empty, use in-cluster namespace.")
+	fs.StringVar(&o.BootstrapKubeconfig, BootstrapKubeconfigFlagName, "", "Path to a bootstrap kubeconfig.")
+	fs.BoolVar(&o.Rotate, RotateFlagName, false, "Whether to use automatic certificate / config rotation.")
+	fs.StringVar(&o.EgressSelectorConfig, EgressSelectorConfigFlagName, "", "Path pointing to an egress selector config to use.")
+}
+
+// ApplyToGetConfig implements GetConfigOption.
+func (o *GetConfigOptions) ApplyToGetConfig(o2 *GetConfigOptions) {
+	if o.Context != "" {
+		o2.Context = o.Context
+	}
+	if o.Kubeconfig != "" {
+		o2.Kubeconfig = o.Kubeconfig
+	}
+	if o.KubeconfigSecretName != "" {
+		o2.KubeconfigSecretName = o.KubeconfigSecretName
+	}
+	if o.KubeconfigSecretNamespace != "" {
+		o2.KubeconfigSecretNamespace = o.KubeconfigSecretNamespace
+	}
+	if o.BootstrapKubeconfig != "" {
+		o2.BootstrapKubeconfig = o.BootstrapKubeconfig
+	}
+	if o.Rotate {
+		o2.Rotate = o.Rotate
+	}
+	if o.EgressSelectorConfig != "" {
+		o2.EgressSelectorConfig = o.EgressSelectorConfig
+	}
+	if o.EgressSelectionName != "" {
+		o2.EgressSelectionName = o.EgressSelectionName
+	}
+}
+
+// ApplyOptions applies all GetConfigOption tro this GetConfigOptions.
+func (o *GetConfigOptions) ApplyOptions(opts []GetConfigOption) {
+	for _, opt := range opts {
+		opt.ApplyToGetConfig(o)
+	}
+}
+
+// Context allows specifying the context to load.
+type Context string
+
+// ApplyToGetConfig implements GetConfigOption.
+func (c Context) ApplyToGetConfig(o *GetConfigOptions) {
+	o.Context = string(c)
+}
+
+// EgressSelectorConfig allows specifying the path to an egress selector config to use.
+type EgressSelectorConfig string
+
+func (c EgressSelectorConfig) ApplyToGetConfig(o *GetConfigOptions) {
+	o.EgressSelectorConfig = string(c)
+}
+
+type WithEgressSelectionName EgressSelectionName
+
+// ApplyToGetConfig implements GetConfigOption.
+func (w WithEgressSelectionName) ApplyToGetConfig(o *GetConfigOptions) {
+	o.EgressSelectionName = EgressSelectionName(w)
+}
+
+// GetConfigOption are options to a GetConfig call.
+type GetConfigOption interface {
+	// ApplyToGetConfig modifies the underlying GetConfigOptions.
+	ApplyToGetConfig(o *GetConfigOptions)
+}
+
+type WithRotate bool
+
+func (w WithRotate) ApplyToGetConfig(o *GetConfigOptions) {
+	o.Rotate = bool(w)
+}
+
+var Rotate = WithRotate(true)

--- a/utils/client/config/store.go
+++ b/utils/client/config/store.go
@@ -1,0 +1,193 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	clientcmdutil "github.com/onmetal/onmetal-api/utils/clientcmd"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Store interface {
+	Get(ctx context.Context) (*rest.Config, error)
+	Set(ctx context.Context, cfg *rest.Config) error
+}
+
+type MemoryStore struct {
+	mu  sync.RWMutex
+	cfg *rest.Config
+}
+
+func (m *MemoryStore) Get(_ context.Context) (*rest.Config, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.cfg == nil {
+		return nil, ErrConfigNotFound
+	}
+	return rest.CopyConfig(m.cfg), nil
+}
+
+func (m *MemoryStore) Set(_ context.Context, cfg *rest.Config) error {
+	if cfg == nil {
+		return fmt.Errorf("must specify cfg")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.cfg = rest.CopyConfig(cfg)
+	return nil
+}
+
+type FileStore string
+
+func (f FileStore) Get(ctx context.Context) (*rest.Config, error) {
+	return FileLoader(f).Load(ctx, nil)
+}
+
+func (f FileStore) Set(_ context.Context, cfg *rest.Config) error {
+	apiCfg, err := clientcmdutil.RESTConfigToConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("error converting rest config to config: %w", err)
+	}
+
+	return clientcmd.WriteToFile(*apiCfg, string(f))
+}
+
+type SecretStore struct {
+	client     client.Client
+	key        client.ObjectKey
+	fieldOwner client.FieldOwner
+	field      string
+}
+
+func (s *SecretStore) Get(ctx context.Context) (*rest.Config, error) {
+	return NewSecretLoader(s.client, s.key, WithField(s.field)).Load(ctx, nil)
+}
+
+func (s *SecretStore) Set(ctx context.Context, cfg *rest.Config) error {
+	apiCfg, err := clientcmdutil.RESTConfigToConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("error transforming rest config to api config: %w", err)
+	}
+
+	if err := clientcmdapi.FlattenConfig(apiCfg); err != nil {
+		return fmt.Errorf("error flattening api config: %w", err)
+	}
+
+	kubeconfigData, err := clientcmd.Write(*apiCfg)
+	if err != nil {
+		return err
+	}
+
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: s.key.Namespace,
+			Name:      s.key.Name,
+		},
+		Data: map[string][]byte{
+			s.field: kubeconfigData,
+		},
+	}
+	if err := s.client.Patch(ctx, secret, client.Apply, s.fieldOwner, client.ForceOwnership); err != nil {
+		return fmt.Errorf("error applying secret %s: %w", s.key, err)
+	}
+	return nil
+}
+
+type SecretStoreOptions struct {
+	Field      string
+	FieldOwner client.FieldOwner
+}
+
+func (o *SecretStoreOptions) ApplyToSecretConfigStore(o2 *SecretStoreOptions) {
+	if o.Field != "" {
+		o2.Field = o.Field
+	}
+	if o.FieldOwner != "" {
+		o2.FieldOwner = o.FieldOwner
+	}
+}
+
+func (o *SecretStoreOptions) ApplyOptions(opts []SecretStoreOption) {
+	for _, opt := range opts {
+		opt.ApplyToSecretConfigStore(o)
+	}
+}
+
+type SecretStoreOption interface {
+	ApplyToSecretConfigStore(o *SecretStoreOptions)
+}
+
+type WithField string
+
+func (w WithField) ApplyToSecretConfigStore(o *SecretStoreOptions) {
+	o.Field = string(w)
+}
+
+func (w WithField) ApplyToSecretLoader(o *SecretLoaderOptions) {
+	o.Field = string(w)
+}
+
+type WithFieldOwner client.FieldOwner
+
+func (w WithFieldOwner) ApplyToSecretConfigStore(o *SecretStoreOptions) {
+	o.FieldOwner = client.FieldOwner(w)
+}
+
+type WithOverrides clientcmd.ConfigOverrides
+
+const (
+	DefaultSecretKubeconfigField            = "kubeconfig"
+	DefaultSecretConfigReadWriterFieldOwner = client.FieldOwner("api.onmetal.de/config-read-writer")
+)
+
+func setSecretConfigReadWriterOptionsDefaults(o *SecretStoreOptions) {
+	if o.Field == "" {
+		o.Field = DefaultSecretKubeconfigField
+	}
+	if o.FieldOwner == "" {
+		o.FieldOwner = DefaultSecretConfigReadWriterFieldOwner
+	}
+}
+
+func NewSecretStore(
+	c client.Client,
+	key client.ObjectKey,
+	opts ...SecretStoreOption,
+) *SecretStore {
+	o := &SecretStoreOptions{}
+	o.ApplyOptions(opts)
+	setSecretConfigReadWriterOptionsDefaults(o)
+
+	return &SecretStore{
+		client:     c,
+		key:        key,
+		fieldOwner: o.FieldOwner,
+		field:      o.Field,
+	}
+}

--- a/utils/client/config/store_test.go
+++ b/utils/client/config/store_test.go
@@ -1,0 +1,176 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/onmetal/onmetal-api/utils/client/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Store", func() {
+	var (
+		apiCfg     *clientcmdapi.Config
+		apiCfgData []byte
+		restCfg    *rest.Config
+	)
+	BeforeEach(func() {
+		apiCfg = &clientcmdapi.Config{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"default": {
+					Server: "https://foo.example.org",
+				},
+			},
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{
+				"default": {
+					Username: "foo",
+					Password: "bar",
+				},
+			},
+			Contexts: map[string]*clientcmdapi.Context{
+				"default": {
+					Cluster:  "default",
+					AuthInfo: "default",
+				},
+			},
+			CurrentContext: "default",
+		}
+		var err error
+		apiCfgData, err = clientcmd.Write(*apiCfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		restCfg = &rest.Config{
+			Host:     "https://foo.example.org",
+			Username: "foo",
+			Password: "bar",
+		}
+	})
+
+	Context("FileStore", func() {
+		var (
+			existingFile    string
+			nonExistentFile string
+		)
+		BeforeEach(func() {
+			tmpFile, err := os.CreateTemp(GinkgoT().TempDir(), "kubeconfig")
+			Expect(err).NotTo(HaveOccurred())
+			existingFile = tmpFile.Name()
+			Expect(tmpFile.Close()).To(Succeed())
+
+			Expect(clientcmd.WriteToFile(*apiCfg, existingFile)).To(Succeed())
+
+			nonExistentFile = "/definitely/should/never/exist"
+		})
+
+		Describe("Get", func() {
+			It("should get the config from file", func(ctx SpecContext) {
+				cfg, err := config.FileStore(existingFile).Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).To(Equal(restCfg))
+			})
+
+			It("should return ErrConfigNotFound if a config does not exist", func(ctx SpecContext) {
+				_, err := config.FileStore(nonExistentFile).Get(ctx)
+				Expect(err).To(MatchError(config.ErrConfigNotFound))
+			})
+		})
+
+		Describe("Set", func() {
+			It("should write the config to the file", func(ctx SpecContext) {
+				filename := filepath.Join(GinkgoT().TempDir(), "config")
+				store := config.FileStore(filename)
+				Expect(store.Set(ctx, restCfg)).To(Succeed())
+
+				data, err := os.ReadFile(filename)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(clientcmd.RESTConfigFromKubeConfig(data)).To(Equal(restCfg))
+			})
+		})
+	})
+
+	Context("SecretStore", func() {
+		var (
+			existingSecretKey    client.ObjectKey
+			nonExistentSecretKey client.ObjectKey
+			ns                   *corev1.Namespace
+		)
+		BeforeEach(func(ctx SpecContext) {
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "ns-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, ns)
+
+			existingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    ns.Name,
+					GenerateName: "kubeconfig-",
+				},
+				Data: map[string][]byte{
+					config.DefaultSecretKubeconfigField: apiCfgData,
+				},
+			}
+			Expect(k8sClient.Create(ctx, existingSecret)).To(Succeed())
+
+			existingSecretKey = client.ObjectKeyFromObject(existingSecret)
+			nonExistentSecretKey = client.ObjectKey{Namespace: ns.Name, Name: "should-definitely-not-exist"}
+		})
+
+		Describe("Get", func() {
+			It("should load the config from the secret", func(ctx SpecContext) {
+				store := config.NewSecretStore(k8sClient, existingSecretKey)
+				cfg, err := store.Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).To(Equal(restCfg))
+			})
+
+			It("should return ErrConfigNotFound if the secret does not exist", func(ctx SpecContext) {
+				store := config.NewSecretStore(k8sClient, nonExistentSecretKey)
+				_, err := store.Get(ctx)
+				Expect(err).To(MatchError(config.ErrConfigNotFound))
+			})
+
+			It("should return ErrConfigNotFound if there is no data at the secret field", func(ctx SpecContext) {
+				store := config.NewSecretStore(k8sClient, existingSecretKey, config.WithField("other-field"))
+				_, err := store.Get(ctx)
+				Expect(err).To(MatchError(config.ErrConfigNotFound))
+			})
+		})
+
+		Describe("Set", func() {
+			It("should set the kubeconfig in the secret", func(ctx SpecContext) {
+				store := config.NewSecretStore(k8sClient, nonExistentSecretKey)
+				Expect(store.Set(ctx, restCfg)).To(Succeed())
+
+				secret := &corev1.Secret{}
+				Expect(k8sClient.Get(ctx, existingSecretKey, secret)).To(Succeed())
+
+				Expect(secret.Data).To(HaveKey(config.DefaultSecretKubeconfigField))
+				Expect(clientcmd.RESTConfigFromKubeConfig(secret.Data[config.DefaultSecretKubeconfigField])).To(Equal(restCfg))
+			})
+		})
+	})
+})

--- a/utils/clientcmd/clientcmd.go
+++ b/utils/clientcmd/clientcmd.go
@@ -1,0 +1,56 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientcmd
+
+import (
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// RESTConfigToConfig transforms a rest.Config to a clientcmdapi.Config.
+// Some properties like e.g. a predefined namespace / proxy cannot be translated and might be lost.
+// Same applies for custom dials / transports that cannot be serialized.
+func RESTConfigToConfig(cfg *rest.Config) (*clientcmdapi.Config, error) {
+	return &clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{"default-cluster": {
+			Server:                   cfg.Host,
+			TLSServerName:            cfg.ServerName,
+			InsecureSkipTLSVerify:    cfg.Insecure,
+			CertificateAuthority:     cfg.CAFile,
+			CertificateAuthorityData: cfg.CAData,
+			DisableCompression:       cfg.DisableCompression,
+		}},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{"default-auth": {
+			ClientCertificate:     cfg.CertFile,
+			ClientCertificateData: cfg.CertData,
+			ClientKey:             cfg.KeyFile,
+			ClientKeyData:         cfg.KeyData,
+			Token:                 cfg.BearerToken,
+			TokenFile:             cfg.BearerTokenFile,
+			Impersonate:           cfg.Impersonate.UserName,
+			ImpersonateUID:        cfg.Impersonate.UID,
+			ImpersonateGroups:     cfg.Impersonate.Groups,
+			ImpersonateUserExtra:  cfg.Impersonate.Extra,
+			Username:              cfg.Username,
+			Password:              cfg.Password,
+		}},
+		Contexts: map[string]*clientcmdapi.Context{"default-context": {
+			Cluster:   "default-cluster",
+			AuthInfo:  "default-auth",
+			Namespace: "default",
+		}},
+		CurrentContext: "default-context",
+	}, nil
+}

--- a/utils/rest/configrotator.go
+++ b/utils/rest/configrotator.go
@@ -1,0 +1,410 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/onmetal/onmetal-api/utils/certificate"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/server/healthz"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func loadConfigs(cfg, bootstrapCfg *rest.Config) (certCfg, clientCfg *rest.Config, initCert *tls.Certificate, err error) {
+	if cfg == nil && bootstrapCfg == nil {
+		return nil, nil, nil, fmt.Errorf("must specify either cfg or bootstrapCfg")
+	}
+
+	if bootstrapCfg == nil || cfg != nil && IsConfigValid(cfg) {
+		initCert, _ := CertificateFromConfig(cfg)
+		return cfg, rest.CopyConfig(cfg), initCert, nil
+	}
+
+	return bootstrapCfg, rest.AnonymousClientConfig(bootstrapCfg), nil, nil
+}
+
+type configRotatorListenerHandle struct {
+	ConfigRotatorListener
+}
+
+type ConfigRotatorListener interface {
+	Enqueue()
+}
+
+type ConfigRotatorListenerFunc func()
+
+func (f ConfigRotatorListenerFunc) Enqueue() {
+	f()
+}
+
+type ConfigRotatorListenerRegistration interface{}
+
+type configRotator struct {
+	startedMu sync.Mutex
+	started   bool
+
+	name           string
+	logConstructor func() logr.Logger
+
+	certRotator certificate.Rotator
+
+	queue workqueue.RateLimitingInterface
+
+	closeConns      func()
+	baseConfig      *rest.Config
+	transportConfig *rest.Config
+	clientConfig    atomic.Pointer[rest.Config]
+
+	listenersMu sync.RWMutex
+	listeners   sets.Set[*configRotatorListenerHandle]
+}
+
+type ConfigRotatorOptions struct {
+	Name                  string
+	SignerName            string
+	Template              *x509.CertificateRequest
+	GetUsages             func(privateKey any) []certificatesv1.KeyUsage
+	RequestedDuration     *time.Duration
+	LogConstructor        func() logr.Logger
+	DialFunc              utilnet.DialFunc
+	NewCertificateRotator func(opts certificate.RotatorOptions) (certificate.Rotator, error)
+	ForceInitial          bool
+}
+
+func setRotatorOptionsDefaults(o *ConfigRotatorOptions) {
+	if o.LogConstructor == nil {
+		o.LogConstructor = func() logr.Logger {
+			return ctrl.Log.WithName(o.Name)
+		}
+	}
+	if o.NewCertificateRotator == nil {
+		o.NewCertificateRotator = certificate.NewRotator
+	}
+	if o.DialFunc == nil {
+		dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+		o.DialFunc = dialer.DialContext
+	}
+}
+
+func NewConfigRotator(cfg, bootstrapCfg *rest.Config, opts ConfigRotatorOptions) (ConfigRotator, error) {
+	if opts.Name == "" {
+		return nil, fmt.Errorf("must specify Name")
+	}
+	if opts.SignerName == "" {
+		return nil, fmt.Errorf("must specify SignerName")
+	}
+	if opts.Template == nil {
+		return nil, fmt.Errorf("must specify Template")
+	}
+	if opts.GetUsages == nil {
+		return nil, fmt.Errorf("must specify GetUsages")
+	}
+	setRotatorOptionsDefaults(&opts)
+
+	certCfg, clientCfg, initCert, err := loadConfigs(cfg, bootstrapCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &configRotator{
+		name:           opts.Name,
+		logConstructor: opts.LogConstructor,
+		baseConfig:     clientCfg,
+		listeners:      sets.New[*configRotatorListenerHandle](),
+	}
+
+	certRotator, err := opts.NewCertificateRotator(certificate.RotatorOptions{
+		Name: opts.Name,
+		NewClient: func(cert *tls.Certificate) (client.WithWatch, error) {
+			cfg := certCfg
+			if cert != nil {
+				cfg = r.clientConfig.Load()
+			}
+
+			return client.NewWithWatch(cfg, client.Options{})
+		},
+		LogConstructor: func() logr.Logger {
+			return opts.LogConstructor().WithName("certificate").WithValues("rotator", opts.Name)
+		},
+		SignerName:        opts.SignerName,
+		Template:          opts.Template,
+		GetUsages:         opts.GetUsages,
+		RequestedDuration: opts.RequestedDuration,
+		ForceInitial:      opts.ForceInitial,
+		InitCertificate:   initCert,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating certificate configRotator: %w", err)
+	}
+
+	r.certRotator = certRotator
+
+	transportConfig, closeConns, err := DynamicCertificateConfig(clientCfg, certRotator.Certificate, opts.DialFunc)
+	if err != nil {
+		return nil, fmt.Errorf("error creating dynamic certificate configuration: %w", err)
+	}
+
+	r.transportConfig = transportConfig
+	r.closeConns = closeConns
+	return r, nil
+}
+
+func (r *configRotator) AddListener(listener ConfigRotatorListener) ConfigRotatorListenerRegistration {
+	r.listenersMu.Lock()
+	defer r.listenersMu.Unlock()
+
+	handle := &configRotatorListenerHandle{listener}
+	r.listeners.Insert(handle)
+	return handle
+}
+
+func (r *configRotator) RemoveListener(reg ConfigRotatorListenerRegistration) {
+	r.listenersMu.Lock()
+	defer r.listenersMu.Unlock()
+
+	handle, ok := reg.(*configRotatorListenerHandle)
+	if !ok {
+		return
+	}
+	r.listeners.Delete(handle)
+}
+
+func (r *configRotator) getListeners() []ConfigRotatorListener {
+	r.listenersMu.RLock()
+	defer r.listenersMu.RUnlock()
+
+	res := make([]ConfigRotatorListener, 0, r.listeners.Len())
+	for handle := range r.listeners {
+		res = append(res, handle.ConfigRotatorListener)
+	}
+	return res
+}
+
+func (r *configRotator) update(_ context.Context) error {
+	r.logConstructor().Info("Config updated, closing connections")
+	r.closeConns()
+
+	cert := r.certRotator.Certificate()
+	if cert == nil {
+		return fmt.Errorf("certificate is not available")
+	}
+
+	clientCfg, err := ConfigWithCertificate(r.baseConfig, cert)
+	if err != nil {
+		return fmt.Errorf("error creating new client config: %w", err)
+	}
+
+	r.logConstructor().Info("Updating client certificate")
+	r.clientConfig.Store(clientCfg)
+
+	listeners := r.getListeners()
+	for _, listener := range listeners {
+		listener.Enqueue()
+	}
+	return nil
+}
+
+func (r *configRotator) processNextWorkItem(ctx context.Context) bool {
+	item, shutdown := r.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer r.queue.Done(item)
+
+	if err := r.update(ctx); err != nil {
+		r.logConstructor().Error(err, "Error updating")
+		r.queue.AddRateLimited(item)
+		return true
+	}
+
+	r.queue.Forget(item)
+	return true
+}
+
+func (r *configRotator) Init(ctx context.Context, force bool) error {
+	if err := r.certRotator.Init(ctx, force); err != nil {
+		return fmt.Errorf("error initializing certificate rotator: %w", err)
+	}
+	if err := r.update(ctx); err != nil {
+		return fmt.Errorf("error updating: %w", err)
+	}
+	return nil
+}
+
+func (r *configRotator) ClientConfig() *rest.Config {
+	return r.clientConfig.Load()
+}
+
+func (r *configRotator) TransportConfig() *rest.Config {
+	return r.transportConfig
+}
+
+const workItemKey = "key"
+
+func (r *configRotator) Start(ctx context.Context) error {
+	r.startedMu.Lock()
+	if r.started {
+		r.startedMu.Unlock()
+		return fmt.Errorf("configRotator already started")
+	}
+
+	r.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	go func() {
+		<-ctx.Done()
+		r.queue.ShutDown()
+	}()
+
+	reg := r.certRotator.AddListener(certificate.RotatorListenerFunc(func() {
+		r.queue.Add(workItemKey)
+	}))
+	defer r.certRotator.RemoveListener(reg)
+
+	var wg sync.WaitGroup
+
+	if err := func() error {
+		defer r.startedMu.Unlock()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = r.certRotator.Start(ctx)
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for r.processNextWorkItem(ctx) {
+			}
+		}()
+
+		r.started = true
+		return nil
+	}(); err != nil {
+		return err
+	}
+
+	<-ctx.Done()
+	wg.Wait()
+	return nil
+}
+
+func (r *configRotator) Name() string {
+	return r.name
+}
+
+func (r *configRotator) Check(req *http.Request) error {
+	return r.certRotator.Check(req)
+}
+
+type ConfigRotator interface {
+	manager.Runnable
+	healthz.HealthChecker
+	Init(ctx context.Context, force bool) error
+	ClientConfig() *rest.Config
+	TransportConfig() *rest.Config
+	AddListener(listener ConfigRotatorListener) ConfigRotatorListenerRegistration
+	RemoveListener(reg ConfigRotatorListenerRegistration)
+}
+
+func RequestConfig(
+	ctx context.Context,
+	certCfg *rest.Config,
+	signerName string,
+	template *x509.CertificateRequest,
+	getUsages func(privateKey any) []certificatesv1.KeyUsage,
+	requestedDuration *time.Duration,
+) (*rest.Config, error) {
+	if certCfg == nil {
+		return nil, fmt.Errorf("must specify certCfg")
+	}
+	if signerName == "" {
+		return nil, fmt.Errorf("must specify signerName")
+	}
+	if template == nil {
+		return nil, fmt.Errorf("must specify template")
+	}
+	if getUsages == nil {
+		return nil, fmt.Errorf("must specify getUsages")
+	}
+
+	c, err := client.NewWithWatch(certCfg, client.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %w", err)
+	}
+
+	cert, err := certificate.RequestCertificate(ctx, c, signerName, template, getUsages, requestedDuration)
+	if err != nil {
+		return nil, fmt.Errorf("error requesting certificate: %w", err)
+	}
+
+	cfg, err := ConfigWithCertificate(certCfg, cert)
+	if err != nil {
+		return nil, fmt.Errorf("error generating config with certificate: %w", err)
+	}
+
+	return cfg, nil
+}
+
+func UseOrRequestConfig(
+	ctx context.Context,
+	cfg *rest.Config,
+	certCfg *rest.Config,
+	signerName string,
+	template *x509.CertificateRequest,
+	getUsages func(privateKey any) []certificatesv1.KeyUsage,
+	requestedDuration *time.Duration,
+) (resCfg *rest.Config, newConfig bool, err error) {
+	if certCfg == nil {
+		return nil, false, fmt.Errorf("must specify certCfg")
+	}
+	if signerName == "" {
+		return nil, false, fmt.Errorf("must specify signerName")
+	}
+	if template == nil {
+		return nil, false, fmt.Errorf("must specify template")
+	}
+	if getUsages == nil {
+		return nil, false, fmt.Errorf("must specify getUsages")
+	}
+	if IsConfigValid(cfg) {
+		return cfg, false, nil
+	}
+	if certCfg == nil {
+		return nil, false, fmt.Errorf("cfg is invalid and certCfg is nil")
+	}
+
+	newCfg, err := RequestConfig(ctx, certCfg, signerName, template, getUsages, requestedDuration)
+	if err != nil {
+		return nil, false, fmt.Errorf("error requesting config: %w", err)
+	}
+
+	return newCfg, true, nil
+}

--- a/utils/rest/configrotator_test.go
+++ b/utils/rest/configrotator_test.go
@@ -1,0 +1,149 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/onmetal/onmetal-api/utils/certificate"
+	certificatetesting "github.com/onmetal/onmetal-api/utils/certificate/testing"
+	. "github.com/onmetal/onmetal-api/utils/rest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/authorization/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var _ = Describe("ConfigRotator", func() {
+	It("should rotate the certificates", func(ctx SpecContext) {
+		By("initializing a bootstrap kubeconfig and a kubeconfig store filepath")
+		bootstrapUser, err := testEnv.AddUser(envtest.User{
+			Name:   "Bootstrap",
+			Groups: []string{"system:authenticated"},
+		}, cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating an authenticated user")
+		authenticatedUser, err := testEnv.AddUser(envtest.User{
+			Name:   "Authenticated",
+			Groups: []string{"system:authenticated", "system:masters"},
+		}, cfg)
+		Expect(err).NotTo(HaveOccurred())
+		authenticatedUserCertData, authenticatedUserKeyData := authenticatedUser.Config().CertData, authenticatedUser.Config().KeyData
+		authenticatedUserCert, err := tls.X509KeyPair(authenticatedUserCertData, authenticatedUserKeyData)
+		Expect(err).NotTo(HaveOccurred())
+
+		certRotator := certificatetesting.NewFakeRotator()
+
+		By("creating a rotator")
+		template := &x509.CertificateRequest{}
+		signerName := "rotator-signer.api.onmetal.de"
+		requestedDuration := pointer.Duration(1 * time.Hour)
+		rotatorName := "rotator"
+		r, err := NewConfigRotator(nil, bootstrapUser.Config(), ConfigRotatorOptions{
+			Name:              rotatorName,
+			SignerName:        signerName,
+			Template:          template,
+			RequestedDuration: requestedDuration,
+			GetUsages: func(privateKey any) []certificatesv1.KeyUsage {
+				return []certificatesv1.KeyUsage{certificatesv1.UsageKeyEncipherment}
+			},
+			LogConstructor: func() logr.Logger {
+				return GinkgoLogr
+			},
+			NewCertificateRotator: func(opts certificate.RotatorOptions) (certificate.Rotator, error) {
+				Expect(opts.Name).To(Equal(rotatorName))
+				Expect(opts.SignerName).To(Equal(signerName))
+				Expect(opts.Template).To(Equal(template))
+				Expect(opts.RequestedDuration).To(Equal(requestedDuration))
+				Expect(opts.ForceInitial).To(BeFalse())
+				Expect(opts.InitCertificate).To(BeNil())
+				return certRotator, nil
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("running the rotator")
+		rotatorDone := make(chan struct{})
+		rotatorCtx, cancelRotator := context.WithCancel(ctx)
+		defer cancelRotator()
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(rotatorDone)
+			Expect(r.Start(rotatorCtx)).To(Succeed())
+		}()
+
+		By("waiting for the certificate rotator to be started")
+		Eventually(ctx, certRotator.Started).Should(BeTrue(), "cert rotator was not started")
+
+		By("asserting there is no client config available and the rotator marks itself as unhealthy")
+		Consistently(ctx, func(g Gomega) {
+			g.Expect(r.ClientConfig()).To(BeNil())
+			g.Expect(r.Check(nil)).To(HaveOccurred())
+		}).Should(Succeed())
+
+		By("creating a client")
+		c, err := kubernetes.NewForConfig(r.TransportConfig())
+		Expect(err).NotTo(HaveOccurred())
+
+		By("asserting we are not authenticated")
+		_, err = c.AuthorizationV1().SelfSubjectRulesReviews().Create(ctx, &v1.SelfSubjectRulesReview{
+			Spec: v1.SelfSubjectRulesReviewSpec{
+				Namespace: corev1.NamespaceDefault,
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).To(Satisfy(apierrors.IsForbidden))
+
+		By("setting the certificate to the one of the authenticated user")
+		certRotator.SetCertificate(&authenticatedUserCert)
+		certRotator.EnqueueAll()
+
+		By("waiting for the client config to be available and the rotator to report as healthy")
+		var clientConfig *rest.Config
+		Eventually(ctx, func(g Gomega) {
+			clientConfig = r.ClientConfig()
+			g.Expect(clientConfig).NotTo(BeNil())
+			g.Expect(clientConfig.CertData).To(Equal(authenticatedUserCertData))
+			g.Expect(clientConfig.KeyData).To(Equal(authenticatedUserKeyData))
+			g.Expect(r.Check(nil)).NotTo(HaveOccurred())
+		}).Should(Succeed())
+
+		By("asserting we are now authenticated")
+		_, err = c.AuthorizationV1().SelfSubjectRulesReviews().Create(ctx, &v1.SelfSubjectRulesReview{
+			Spec: v1.SelfSubjectRulesReviewSpec{
+				Namespace: corev1.NamespaceDefault,
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("stopping the rotator")
+		cancelRotator()
+
+		By("waiting for the rotator to stop")
+		Eventually(rotatorDone).Should(BeClosed())
+	})
+})

--- a/utils/rest/rest_suite_test.go
+++ b/utils/rest/rest_suite_test.go
@@ -1,0 +1,73 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	authv1 "k8s.io/api/authentication/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const (
+	pollingInterval      = 50 * time.Millisecond
+	eventuallyTimeout    = 3 * time.Second
+	consistentlyDuration = 1 * time.Second
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
+
+func TestREST(t *testing.T) {
+	SetDefaultConsistentlyPollingInterval(pollingInterval)
+	SetDefaultEventuallyPollingInterval(pollingInterval)
+	SetDefaultEventuallyTimeout(eventuallyTimeout)
+	SetDefaultConsistentlyDuration(consistentlyDuration)
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "REST Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	var err error
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{}
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(testEnv.Stop)
+
+	Expect(authv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	komega.SetClient(k8sClient)
+})

--- a/utils/rest/testing/fake.go
+++ b/utils/rest/testing/fake.go
@@ -1,0 +1,148 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	utilrest "github.com/onmetal/onmetal-api/utils/rest"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
+)
+
+const FakeConfigRotatorName = "fake-config-rotator"
+
+type FakeConfigRotatorListenerHandle struct {
+	utilrest.ConfigRotatorListener
+}
+
+type FakeConfigRotator struct {
+	mu sync.RWMutex
+
+	started         bool
+	clientConfig    *rest.Config
+	transportConfig *rest.Config
+	listeners       sets.Set[*FakeConfigRotatorListenerHandle]
+}
+
+func NewFakeConfigRotator() *FakeConfigRotator {
+	return &FakeConfigRotator{
+		listeners: sets.New[*FakeConfigRotatorListenerHandle](),
+	}
+}
+
+func (f *FakeConfigRotator) Start(ctx context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.started {
+		return fmt.Errorf("rotator already started")
+	}
+	f.started = true
+	return nil
+}
+
+func (f *FakeConfigRotator) Started() bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	return f.started
+}
+
+func (f *FakeConfigRotator) Name() string {
+	return FakeConfigRotatorName
+}
+
+func (f *FakeConfigRotator) Check(req *http.Request) error {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	if f.clientConfig == nil {
+		return fmt.Errorf("client config is unset")
+	}
+
+	if !utilrest.IsConfigValid(f.clientConfig) {
+		return fmt.Errorf("client config is not valid")
+	}
+
+	return nil
+}
+
+func (f *FakeConfigRotator) Init(ctx context.Context, force bool) error {
+	return nil
+}
+
+func (f *FakeConfigRotator) ClientConfig() *rest.Config {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.clientConfig
+}
+
+func (f *FakeConfigRotator) SetClientConfig(cfg *rest.Config) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.clientConfig = cfg
+}
+
+func (f *FakeConfigRotator) TransportConfig() *rest.Config {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.transportConfig
+}
+
+func (f *FakeConfigRotator) SetTransportConfig(cfg *rest.Config) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.transportConfig = cfg
+}
+
+func (f *FakeConfigRotator) AddListener(listener utilrest.ConfigRotatorListener) utilrest.ConfigRotatorListenerRegistration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	handle := &FakeConfigRotatorListenerHandle{listener}
+	f.listeners.Insert(handle)
+	return nil
+}
+
+func (f *FakeConfigRotator) RemoveListener(reg utilrest.ConfigRotatorListenerRegistration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	handle, ok := reg.(*FakeConfigRotatorListenerHandle)
+	if !ok {
+		return
+	}
+	f.listeners.Delete(handle)
+}
+
+func (f *FakeConfigRotator) Listeners() []utilrest.ConfigRotatorListener {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	res := make([]utilrest.ConfigRotatorListener, 0, len(f.listeners))
+	for handle := range f.listeners {
+		res = append(res, handle.ConfigRotatorListener)
+	}
+	return res
+}
+
+func (f *FakeConfigRotator) EnqueueAll() {
+	listeners := f.Listeners()
+	for _, listener := range listeners {
+		listener.Enqueue()
+	}
+}

--- a/utils/rest/util.go
+++ b/utils/rest/util.go
@@ -1,0 +1,148 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/onmetal/onmetal-api/utils/certificate"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/rest"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/connrotation"
+)
+
+func ConfigWithCertificate(cfg *rest.Config, cert *tls.Certificate) (*rest.Config, error) {
+	certData, keyData, err := certificate.Marshal(cert)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling tls certificate: %w", err)
+	}
+
+	certCfg := rest.AnonymousClientConfig(cfg)
+	certCfg.CertData = certData
+	certCfg.KeyData = keyData
+	return certCfg, nil
+}
+
+func CertificateFromConfig(cfg *rest.Config) (*tls.Certificate, error) {
+	if cfg.CertData == nil && cfg.CertFile != "" {
+		certData, err := os.ReadFile(cfg.CertFile)
+		if err != nil {
+			return nil, fmt.Errorf("error reading certificate file %q: %w", cfg.CertFile, err)
+		}
+
+		cfg.CertData = certData
+	}
+
+	if cfg.KeyData == nil && cfg.KeyFile != "" {
+		keyData, err := os.ReadFile(cfg.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("error reading key file %q: %w", cfg.KeyFile, err)
+		}
+
+		cfg.KeyData = keyData
+	}
+
+	if cfg.CertData == nil && cfg.KeyData == nil {
+		return nil, nil
+	}
+
+	cert, err := tls.X509KeyPair(cfg.CertData, cfg.KeyData)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing key pair: %w", err)
+	}
+
+	return &cert, nil
+}
+
+func DynamicCertificateConfig(
+	cfg *rest.Config,
+	getCertificate func() *tls.Certificate,
+	dialFunc utilnet.DialFunc,
+) (*rest.Config, func(), error) {
+	if cfg.Transport != nil || cfg.Dial != nil {
+		return nil, nil, fmt.Errorf("cannot override preconfigured transport / dialer for dynamic certificate config")
+	}
+
+	cfg = rest.AnonymousClientConfig(cfg)
+	tlsConfig, err := rest.TLSConfigFor(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting tls config: %w", err)
+	}
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+
+	tlsConfig.Certificates = nil
+	tlsConfig.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		cert := getCertificate()
+		if cert == nil {
+			return &tls.Certificate{Certificate: nil}, nil
+		}
+		return cert, nil
+	}
+
+	d := connrotation.NewDialer(connrotation.DialFunc(dialFunc))
+	cfg.Transport = utilnet.SetTransportDefaults(&http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsConfig,
+		MaxIdleConnsPerHost: 25,
+		DialContext:         d.DialContext,
+	})
+
+	// Zero out all existing TLS options since our new transport enforces them.
+	cfg.CertData = nil
+	cfg.KeyData = nil
+	cfg.CertFile = ""
+	cfg.KeyFile = ""
+	cfg.CAData = nil
+	cfg.CAFile = ""
+	cfg.Insecure = false
+	cfg.NextProtos = nil
+
+	return cfg, d.CloseAll, nil
+}
+
+func IsConfigValid(cfg *rest.Config) bool {
+	if cfg == nil {
+		return false
+	}
+
+	transportCfg, err := cfg.TransportConfig()
+	if err != nil {
+		return false
+	}
+
+	certs, err := certutil.ParseCertsPEM(transportCfg.TLS.CertData)
+	if err != nil {
+		return false
+	}
+	if len(certs) == 0 {
+		return false
+	}
+
+	now := time.Now()
+	for _, cert := range certs {
+		if now.After(cert.NotAfter) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
* Create certificate signer controller + recognizer interface to plug in multiple recognizers (in our case, `MachinePool`, `VolumePool`, `BucketPool`).
* Create `certificate`, `rest` and `config` `Rotator`s to rotate kubeconfigs + helpers
* Add `client/config.Getter` to get `*rest.Config`s and `config.Controller`s depending on given command line arguments
* Add test cases
* Add bootstrapper roles + pool roles to enable creating bootstrap tokens