### PR TITLE
Update workflows for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+    - name: Dependabot metadata
+      id: metadata
+      uses: dependabot/fetch-metadata@v1
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Approve the PR
+      run: gh pr review --approve "$PR_URL"
+      env:
+        PR_URL: ${{github.event.pull_request.html_url}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Enable auto-merge for Dependabot PRs
+      run: gh pr merge --auto --merge "$PR_URL"
+      env:
+        PR_URL: ${{github.event.pull_request.html_url}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/docs-check-codegen.yml
+++ b/.github/workflows/docs-check-codegen.yml
@@ -1,0 +1,13 @@
+name: Check Codegen
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+    - '**/*.md'
+
+jobs:
+  check-codegen:
+    runs-on: ubuntu-latest
+    steps:
+    - run: 'echo "No check-codegen required"'

--- a/.github/workflows/docs-kustomize-validation.yml
+++ b/.github/workflows/docs-kustomize-validation.yml
@@ -1,0 +1,13 @@
+name: Kustomize Validation
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+    - '**/*.md'
+
+jobs:
+  kustomize-validation:
+    runs-on: ubuntu-latest
+    steps:
+    - run: 'echo "No kustomize validation required"'

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,13 @@
+name: Lint Docs
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+    - '**/*.md'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - run: 'echo "No lint required"'

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -1,0 +1,14 @@
+name: Pull Request Docs test
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+    - '**/*.md'
+
+jobs:
+  checks:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+    - run: 'echo "No test required"'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint Golang Codebase
+name: Lint
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   checks:
-    name: run
+    name: test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
* Create workflows that run in the docs-case to give a green light to required status checks
* Create the `dependabot-auto-merge.yml` workflow, a workflow that auto-approves dependabot PRs and marks them for auto-merge
* Update (some) existing workflows to align more nicely with the naming scheme.