### PR TITLE
machinepoollet downward api labels / annotations

### DIFF
--- a/poollet/machinepoollet/api/v1alpha1/common_types.go
+++ b/poollet/machinepoollet/api/v1alpha1/common_types.go
@@ -27,4 +27,17 @@ const (
 
 	FieldOwner       = "machinepoollet.api.onmetal.de/field-owner"
 	MachineFinalizer = "machinepoollet.api.onmetal.de/machine"
+
+	// DownwardAPIPrefix is the prefix for any downward label.
+	DownwardAPIPrefix = "downward-api.machinepoollet.api.onmetal.de/"
 )
+
+// DownwardAPILabel makes a downward api label name from the given name.
+func DownwardAPILabel(name string) string {
+	return DownwardAPIPrefix + name
+}
+
+// DownwardAPIAnnotation makes a downward api annotation name from the given name.
+func DownwardAPIAnnotation(name string) string {
+	return DownwardAPIPrefix + name
+}

--- a/poollet/machinepoollet/cmd/machinepoollet/app/app.go
+++ b/poollet/machinepoollet/cmd/machinepoollet/app/app.go
@@ -71,6 +71,8 @@ type Options struct {
 	ProbeAddr                string
 
 	MachinePoolName                      string
+	MachineDownwardAPILabels             map[string]string
+	MachineDownwardAPIAnnotations        map[string]string
 	ProviderID                           string
 	MachineRuntimeEndpoint               string
 	MachineRuntimeSocketDiscoveryTimeout time.Duration
@@ -95,6 +97,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.LeaderElectionKubeconfig, "leader-election-kubeconfig", "", "Path pointing to a kubeconfig to use for leader election.")
 
 	fs.StringVar(&o.MachinePoolName, "machine-pool-name", o.MachinePoolName, "Name of the machine pool to announce / watch")
+	fs.StringToStringVar(&o.MachineDownwardAPILabels, "machine-downward-api-label", o.MachineDownwardAPILabels, "Downward-API labels to set on the ori machine.")
+	fs.StringToStringVar(&o.MachineDownwardAPIAnnotations, "machine-downward-api-annotation", o.MachineDownwardAPIAnnotations, "Downward-API annotations to set on the ori machine.")
 	fs.StringVar(&o.ProviderID, "provider-id", "", "Provider id to announce on the machine pool.")
 	fs.StringVar(&o.MachineRuntimeEndpoint, "machine-runtime-endpoint", o.MachineRuntimeEndpoint, "Endpoint of the remote machine runtime service.")
 	fs.DurationVar(&o.MachineRuntimeSocketDiscoveryTimeout, "machine-runtime-socket-discovery-timeout", 20*time.Second, "Timeout for discovering the machine runtime socket.")
@@ -335,14 +339,16 @@ func Run(ctx context.Context, opts Options) error {
 		}
 
 		if err := (&controllers.MachineReconciler{
-			EventRecorder:         mgr.GetEventRecorderFor("machines"),
-			Client:                mgr.GetClient(),
-			MachineRuntime:        machineRuntime,
-			MachineRuntimeName:    version.RuntimeName,
-			MachineRuntimeVersion: version.RuntimeVersion,
-			MachineClassMapper:    machineClassMapper,
-			MachinePoolName:       opts.MachinePoolName,
-			WatchFilterValue:      opts.WatchFilterValue,
+			EventRecorder:          mgr.GetEventRecorderFor("machines"),
+			Client:                 mgr.GetClient(),
+			MachineRuntime:         machineRuntime,
+			MachineRuntimeName:     version.RuntimeName,
+			MachineRuntimeVersion:  version.RuntimeVersion,
+			MachineClassMapper:     machineClassMapper,
+			MachinePoolName:        opts.MachinePoolName,
+			DownwardAPILabels:      opts.MachineDownwardAPILabels,
+			DownwardAPIAnnotations: opts.MachineDownwardAPIAnnotations,
+			WatchFilterValue:       opts.WatchFilterValue,
 		}).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("error setting up machine reconciler with manager: %w", err)
 		}

--- a/poollet/machinepoollet/controllers/controllers_suite_test.go
+++ b/poollet/machinepoollet/controllers/controllers_suite_test.go
@@ -16,6 +16,7 @@ package controllers_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -65,6 +66,9 @@ const (
 	apiServiceTimeout    = 5 * time.Minute
 
 	controllerManagerService = "controller-manager"
+
+	fooDownwardAPILabel = "custom-downward-api-label"
+	fooAnnotation       = "foo"
 )
 
 func TestControllers(t *testing.T) {
@@ -220,6 +224,9 @@ func SetupTest(ctx context.Context) (*corev1.Namespace, *computev1alpha1.Machine
 			MachineRuntimeVersion: machine.FakeVersion,
 			MachineClassMapper:    machineClassMapper,
 			MachinePoolName:       mp.Name,
+			DownwardAPILabels: map[string]string{
+				fooDownwardAPILabel: fmt.Sprintf("metadata.annotations['%s']", fooAnnotation),
+			},
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
 		go func() {


### PR DESCRIPTION
This change allows a `machinepoollet` to define downward API labels & annotations. By doing so, relevant information from the metadata of a machine may be transmitted to the ORI machine without making any hard-coded assumptions about the machine API.