### PR TITLE
Add `ResizePolicy` to `VolumeClass` type

### DIFF
--- a/api/storage/v1alpha1/volumeclass_types.go
+++ b/api/storage/v1alpha1/volumeclass_types.go
@@ -36,7 +36,20 @@ type VolumeClass struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Capabilities describes the capabilities of a VolumeClass.
 	Capabilities corev1alpha1.ResourceList `json:"capabilities,omitempty"`
+	// ResizePolicy describes the supported expansion policy of a VolumeClass.
+	// If not set default to Static expansion policy.
+	ResizePolicy ResizePolicy `json:"resizePolicy,omitempty"`
 }
+
+// ResizePolicy is a type of policy.
+type ResizePolicy string
+
+const (
+	// ResizePolicyStatic is a policy that does not allow the expansion of a Volume.
+	ResizePolicyStatic ResizePolicy = "Static"
+	// ResizePolicyExpandOnly is a policy that only allows the expansion of a Volume.
+	ResizePolicyExpandOnly ResizePolicy = "ExpandOnly"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/broker/volumebroker/server/volume_create.go
+++ b/broker/volumebroker/server/volume_create.go
@@ -131,7 +131,7 @@ func (s *Server) createOnmetalVolume(ctx context.Context, log logr.Logger, volum
 
 	log.V(1).Info("Patching onmetal volume as created")
 	if err := apiutils.PatchCreated(ctx, s.client, volume.Volume); err != nil {
-		return fmt.Errorf("error patching onmetal machine as created: %w", err)
+		return fmt.Errorf("error patching onmetal volume as created: %w", err)
 	}
 
 	// Reset cleaner since everything from now on operates on a consistent volume

--- a/client-go/applyconfigurations/internal/internal.go
+++ b/client-go/applyconfigurations/internal/internal.go
@@ -1590,6 +1590,9 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
       default: {}
+    - name: resizePolicy
+      type:
+        scalar: string
 - name: com.github.onmetal.onmetal-api.api.storage.v1alpha1.VolumeCondition
   map:
     fields:

--- a/client-go/applyconfigurations/storage/v1alpha1/volumeclass.go
+++ b/client-go/applyconfigurations/storage/v1alpha1/volumeclass.go
@@ -32,7 +32,8 @@ import (
 type VolumeClassApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Capabilities                     *v1alpha1.ResourceList `json:"capabilities,omitempty"`
+	Capabilities                     *v1alpha1.ResourceList        `json:"capabilities,omitempty"`
+	ResizePolicy                     *storagev1alpha1.ResizePolicy `json:"resizePolicy,omitempty"`
 }
 
 // VolumeClass constructs an declarative configuration of the VolumeClass type for use with
@@ -243,5 +244,13 @@ func (b *VolumeClassApplyConfiguration) ensureObjectMetaApplyConfigurationExists
 // If called multiple times, the Capabilities field is set to the value of the last call.
 func (b *VolumeClassApplyConfiguration) WithCapabilities(value v1alpha1.ResourceList) *VolumeClassApplyConfiguration {
 	b.Capabilities = &value
+	return b
+}
+
+// WithResizePolicy sets the ResizePolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ResizePolicy field is set to the value of the last call.
+func (b *VolumeClassApplyConfiguration) WithResizePolicy(value storagev1alpha1.ResizePolicy) *VolumeClassApplyConfiguration {
+	b.ResizePolicy = &value
 	return b
 }

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -5618,6 +5618,13 @@ func schema_onmetal_api_api_storage_v1alpha1_VolumeClass(ref common.ReferenceCal
 							},
 						},
 					},
+					"resizePolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ResizePolicy describes the supported expansion policy of a VolumeClass. If not set default to Static expansion policy.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -565,6 +565,20 @@ github.com/onmetal/onmetal-api/api/core/v1alpha1.ResourceList
 <p>Capabilities describes the capabilities of a VolumeClass.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>resizePolicy</code><br/>
+<em>
+<a href="#storage.api.onmetal.de/v1alpha1.ResizePolicy">
+ResizePolicy
+</a>
+</em>
+</td>
+<td>
+<p>ResizePolicy describes the supported expansion policy of a VolumeClass.
+If not set default to Static expansion policy.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="storage.api.onmetal.de/v1alpha1.VolumePool">VolumePool
@@ -1180,6 +1194,29 @@ covered by Tolerations will be considered to host the Bucket.</p>
 </td>
 </tr>
 </tbody>
+</table>
+<h3 id="storage.api.onmetal.de/v1alpha1.ResizePolicy">ResizePolicy
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#storage.api.onmetal.de/v1alpha1.VolumeClass">VolumeClass</a>)
+</p>
+<div>
+<p>ResizePolicy is a type of policy.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;ExpandOnly&#34;</p></td>
+<td><p>ResizePolicyExpandOnly is a policy that only allows the expansion of a Volume.</p>
+</td>
+</tr><tr><td><p>&#34;Static&#34;</p></td>
+<td><p>ResizePolicyStatic is a policy that does not allow the expansion of a Volume.</p>
+</td>
+</tr></tbody>
 </table>
 <h3 id="storage.api.onmetal.de/v1alpha1.VolumeAccess">VolumeAccess
 </h3>

--- a/gen/v3/apis__compute.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__compute.api.onmetal.de__v1alpha1_openapi.json
@@ -34698,6 +34698,10 @@
 					},
 					"metadata": {
 						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"resizePolicy": {
+						"description": "ResizePolicy describes the supported expansion policy of a VolumeClass. If not set default to Static expansion policy.",
+						"type": "string"
 					}
 				},
 				"x-kubernetes-group-version-kind": [

--- a/gen/v3/apis__core.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__core.api.onmetal.de__v1alpha1_openapi.json
@@ -34698,6 +34698,10 @@
 					},
 					"metadata": {
 						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"resizePolicy": {
+						"description": "ResizePolicy describes the supported expansion policy of a VolumeClass. If not set default to Static expansion policy.",
+						"type": "string"
 					}
 				},
 				"x-kubernetes-group-version-kind": [

--- a/gen/v3/apis__ipam.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__ipam.api.onmetal.de__v1alpha1_openapi.json
@@ -34698,6 +34698,10 @@
 					},
 					"metadata": {
 						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"resizePolicy": {
+						"description": "ResizePolicy describes the supported expansion policy of a VolumeClass. If not set default to Static expansion policy.",
+						"type": "string"
 					}
 				},
 				"x-kubernetes-group-version-kind": [

--- a/gen/v3/apis__networking.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__networking.api.onmetal.de__v1alpha1_openapi.json
@@ -34698,6 +34698,10 @@
 					},
 					"metadata": {
 						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"resizePolicy": {
+						"description": "ResizePolicy describes the supported expansion policy of a VolumeClass. If not set default to Static expansion policy.",
+						"type": "string"
 					}
 				},
 				"x-kubernetes-group-version-kind": [

--- a/gen/v3/apis__storage.api.onmetal.de__v1alpha1_openapi.json
+++ b/gen/v3/apis__storage.api.onmetal.de__v1alpha1_openapi.json
@@ -34698,6 +34698,10 @@
 					},
 					"metadata": {
 						"$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+					},
+					"resizePolicy": {
+						"description": "ResizePolicy describes the supported expansion policy of a VolumeClass. If not set default to Static expansion policy.",
+						"type": "string"
 					}
 				},
 				"x-kubernetes-group-version-kind": [

--- a/internal/admission/plugin/volumeresize/admission.go
+++ b/internal/admission/plugin/volumeresize/admission.go
@@ -1,0 +1,126 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package volumeresize
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/onmetal/onmetal-api/api/storage/v1alpha1"
+	"github.com/onmetal/onmetal-api/client-go/onmetalapi"
+	"github.com/onmetal/onmetal-api/internal/apis/core"
+	"github.com/onmetal/onmetal-api/internal/apis/storage"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const PluginName = "VolumeExpansion"
+
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return NewVolumeExpansion(), nil
+	})
+}
+
+type VolumeExpansion struct {
+	client onmetalapi.Interface
+	*admission.Handler
+}
+
+func NewVolumeExpansion() admission.Interface {
+	return &VolumeExpansion{
+		Handler: admission.NewHandler(admission.Update),
+	}
+}
+
+func (v *VolumeExpansion) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	if shouldIgnore(a) {
+		return nil
+	}
+
+	volume, ok := a.GetObject().(*storage.Volume)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Volume but was unable to be converted")
+	}
+
+	oldVolume, ok := a.GetOldObject().(*storage.Volume)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Volume but was unable to be converted")
+	}
+
+	volumeSize, ok := volume.Spec.Resources[core.ResourceStorage]
+	if !ok {
+		return apierrors.NewBadRequest("Volume does not contain any capacity information")
+	}
+
+	oldVolumeSize, ok := oldVolume.Spec.Resources[core.ResourceStorage]
+	if !ok {
+		return apierrors.NewBadRequest("Old Volume does not contain any capacity information")
+	}
+
+	if volumeSize.Equal(oldVolumeSize) {
+		return nil
+	}
+
+	// Volume size changed, therefore we need to check whether the VolumeClass supports Volume expansion
+	volumeClass, err := v.client.StorageV1alpha1().VolumeClasses().Get(ctx, volume.Spec.VolumeClassRef.Name, v1.GetOptions{})
+	if err != nil {
+		return apierrors.NewBadRequest(fmt.Sprintf("Could not get VolumeClass for Volume: %v", err))
+	}
+
+	switch volumeClass.ResizePolicy {
+	case v1alpha1.ResizePolicyStatic:
+		if volumeSize.Value() != oldVolumeSize.Value() {
+			return apierrors.NewBadRequest("VolumeClass ResizePolicy does not allow resizing")
+		}
+	case v1alpha1.ResizePolicyExpandOnly:
+		if volumeSize.Value() < oldVolumeSize.Value() {
+			return apierrors.NewBadRequest("VolumeClass ResizePolicy does not allow shrinking")
+		}
+	default:
+		return nil
+	}
+
+	return nil
+}
+
+func (v *VolumeExpansion) SetExternalOnmetalClientSet(client onmetalapi.Interface) {
+	v.client = client
+}
+
+func (v *VolumeExpansion) ValidateInitialization() error {
+	if v.client == nil {
+		return fmt.Errorf("missing client")
+	}
+	return nil
+}
+
+func shouldIgnore(a admission.Attributes) bool {
+	if a.GetKind().GroupKind() != storage.Kind("Volume") {
+		return true
+	}
+
+	volume, ok := a.GetObject().(*storage.Volume)
+	if !ok {
+		return true
+	}
+
+	if volume.Spec.VolumeClassRef == nil {
+		return true
+	}
+	return false
+}

--- a/internal/admission/plugin/volumeresize/admission_test.go
+++ b/internal/admission/plugin/volumeresize/admission_test.go
@@ -1,0 +1,163 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package volumeresize_test
+
+import (
+	corev1alpha1 "github.com/onmetal/onmetal-api/api/core/v1alpha1"
+	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
+	. "github.com/onmetal/onmetal-api/utils/testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+)
+
+var _ = Describe("Admission", func() {
+	ctx := SetupContext()
+	ns, volumePool := SetupTest(ctx)
+
+	var (
+		volumeClassStatic     = &storagev1alpha1.VolumeClass{}
+		volumeClassExpandOnly = &storagev1alpha1.VolumeClass{}
+	)
+
+	BeforeEach(func() {
+		By("creating an expand only VolumeClass")
+		volumeClassExpandOnly = &storagev1alpha1.VolumeClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "expand-only",
+			},
+			Capabilities: corev1alpha1.ResourceList{
+				corev1alpha1.ResourceIOPS: resource.MustParse("100"),
+				corev1alpha1.ResourceTPS:  resource.MustParse("100"),
+			},
+			ResizePolicy: storagev1alpha1.ResizePolicyExpandOnly,
+		}
+		Expect(k8sClient.Create(ctx, volumeClassExpandOnly)).To(Succeed())
+
+		By("creating a static VolumeClass")
+		volumeClassStatic = &storagev1alpha1.VolumeClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "static",
+			},
+			Capabilities: corev1alpha1.ResourceList{
+				corev1alpha1.ResourceIOPS: resource.MustParse("100"),
+				corev1alpha1.ResourceTPS:  resource.MustParse("100"),
+			},
+			ResizePolicy: storagev1alpha1.ResizePolicyStatic,
+		}
+		Expect(k8sClient.Create(ctx, volumeClassStatic)).To(Succeed())
+	})
+
+	It("should allow the resizing of a Volume if the VolumeClass supports it", func() {
+		By("creating a Volume")
+		volume := &storagev1alpha1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "volume-",
+			},
+			Spec: storagev1alpha1.VolumeSpec{
+				VolumeClassRef: &corev1.LocalObjectReference{Name: volumeClassExpandOnly.Name},
+				VolumePoolRef:  &corev1.LocalObjectReference{Name: volumePool.Name},
+				Resources: corev1alpha1.ResourceList{
+					corev1alpha1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, volume)).To(Succeed())
+
+		By("patching the Volume to increase the Volume size")
+		volumeBase := volume.DeepCopy()
+		volume.Spec.Resources[corev1alpha1.ResourceStorage] = resource.MustParse("2Gi")
+		Expect(k8sClient.Patch(ctx, volume, client.MergeFrom(volumeBase)))
+
+		By("ensuring that Volume has been resized")
+		Consistently(Object(volume)).Should(SatisfyAll(
+			HaveField("Spec.Resources", Equal(corev1alpha1.ResourceList{
+				corev1alpha1.ResourceStorage: resource.MustParse("2Gi"),
+			})),
+		))
+	})
+
+	It("should not allow the resizing of a Volume if the VolumeClass does not support it", func() {
+		By("creating a Volume")
+		volume := &storagev1alpha1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "volume-",
+			},
+			Spec: storagev1alpha1.VolumeSpec{
+				VolumeClassRef: &corev1.LocalObjectReference{Name: volumeClassStatic.Name},
+				VolumePoolRef:  &corev1.LocalObjectReference{Name: volumePool.Name},
+				Resources: corev1alpha1.ResourceList{
+					corev1alpha1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, volume)).To(Succeed())
+
+		By("patching the Volume to increase the Volume size")
+		volumeBase := volume.DeepCopy()
+		volume.Spec.Resources[corev1alpha1.ResourceStorage] = resource.MustParse("2Gi")
+		Expect(k8sClient.Patch(ctx, volume, client.MergeFrom(volumeBase))).Should(
+			MatchError(apierrors.NewBadRequest("VolumeClass ResizePolicy does not allow resizing")))
+
+		By("ensuring that Volume has been resized")
+		Consistently(Object(volume)).Should(SatisfyAll(
+			HaveField("Spec.Resources", Equal(corev1alpha1.ResourceList{
+				corev1alpha1.ResourceStorage: resource.MustParse("1Gi"),
+			})),
+		))
+	})
+
+	It("should not allow the shrinking of a Volume if the VolumeClass does not support it", func() {
+		By("creating a Volume")
+		volume := &storagev1alpha1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "volume-",
+			},
+			Spec: storagev1alpha1.VolumeSpec{
+				VolumeClassRef: &corev1.LocalObjectReference{Name: volumeClassExpandOnly.Name},
+				VolumePoolRef:  &corev1.LocalObjectReference{Name: volumePool.Name},
+				Resources: corev1alpha1.ResourceList{
+					corev1alpha1.ResourceStorage: resource.MustParse("2Gi"),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, volume)).To(Succeed())
+
+		By("patching the Volume to decrease the Volume size")
+		volumeBase := volume.DeepCopy()
+		volume.Spec.Resources[corev1alpha1.ResourceStorage] = resource.MustParse("1Gi")
+		Expect(k8sClient.Patch(ctx, volume, client.MergeFrom(volumeBase))).Should(
+			MatchError(apierrors.NewBadRequest("VolumeClass ResizePolicy does not allow shrinking")))
+
+		By("ensuring that Volume has been resized")
+		Consistently(Object(volume)).Should(SatisfyAll(
+			HaveField("Spec.Resources", Equal(corev1alpha1.ResourceList{
+				corev1alpha1.ResourceStorage: resource.MustParse("2Gi"),
+			})),
+		))
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.DeleteAllOf(ctx, &storagev1alpha1.VolumeClass{})).To(Succeed())
+	})
+})

--- a/internal/admission/plugin/volumeresize/volumeexpansion_suite_test.go
+++ b/internal/admission/plugin/volumeresize/volumeexpansion_suite_test.go
@@ -1,0 +1,140 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package volumeresize_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/onmetal/controller-utils/buildutils"
+	utilsenvtest "github.com/onmetal/onmetal-api/utils/envtest"
+	"github.com/onmetal/onmetal-api/utils/envtest/apiserver"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+
+	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	//+kubebuilder:scaffold:imports
+)
+
+const (
+	pollingInterval      = 50 * time.Millisecond
+	eventuallyTimeout    = 3 * time.Second
+	consistentlyDuration = 1 * time.Second
+	apiServiceTimeout    = 5 * time.Minute
+)
+
+var (
+	cfg        *rest.Config
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	testEnvExt *utilsenvtest.EnvironmentExtensions
+)
+
+func TestAPIs(t *testing.T) {
+	SetDefaultConsistentlyPollingInterval(pollingInterval)
+	SetDefaultEventuallyPollingInterval(pollingInterval)
+	SetDefaultEventuallyTimeout(eventuallyTimeout)
+	SetDefaultConsistentlyDuration(consistentlyDuration)
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	var err error
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{}
+	testEnvExt = &utilsenvtest.EnvironmentExtensions{
+		APIServiceDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "apiserver", "apiservice", "bases")},
+		ErrorIfAPIServicePathIsMissing: true,
+	}
+
+	cfg, err = utilsenvtest.StartWithExtensions(testEnv, testEnvExt)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	DeferCleanup(utilsenvtest.StopWithExtensions, testEnv, testEnvExt)
+
+	Expect(storagev1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	komega.SetClient(k8sClient)
+
+	apiSrv, err := apiserver.New(cfg, apiserver.Options{
+		MainPath:     "github.com/onmetal/onmetal-api/cmd/onmetal-apiserver",
+		BuildOptions: []buildutils.BuildOption{buildutils.ModModeMod},
+		ETCDServers:  []string{testEnv.ControlPlane.Etcd.URL.String()},
+		Host:         testEnvExt.APIServiceInstallOptions.LocalServingHost,
+		Port:         testEnvExt.APIServiceInstallOptions.LocalServingPort,
+		CertDir:      testEnvExt.APIServiceInstallOptions.LocalServingCertDir,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(apiSrv.Start()).To(Succeed())
+	DeferCleanup(apiSrv.Stop)
+
+	Expect(utilsenvtest.WaitUntilAPIServicesReadyWithTimeout(apiServiceTimeout, testEnvExt, k8sClient, scheme.Scheme)).To(Succeed())
+})
+
+func SetupTest(ctx context.Context) (*corev1.Namespace, *storagev1alpha1.VolumePool) {
+	var (
+		ns         = &corev1.Namespace{}
+		volumePool = &storagev1alpha1.VolumePool{}
+	)
+	BeforeEach(func() {
+		*ns = corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "testns-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed(), "failed to create test namespace")
+
+		*volumePool = storagev1alpha1.VolumePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: storagev1alpha1.VolumePoolSpec{
+				ProviderID: "foo",
+			},
+		}
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, ns)).To(Succeed(), "failed to delete test namespace")
+		Expect(k8sClient.DeleteAllOf(ctx, &storagev1alpha1.VolumePool{})).To(Succeed())
+	})
+
+	return ns, volumePool
+}

--- a/internal/admission/plugin/volumeresizepolicy/admission.go
+++ b/internal/admission/plugin/volumeresizepolicy/admission.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package volumeresize
+package volumeresizepolicy
 
 import (
 	"context"

--- a/internal/api/validation/corev1.go
+++ b/internal/api/validation/corev1.go
@@ -15,6 +15,7 @@
 package apivalidation
 
 import (
+	"github.com/onmetal/onmetal-api/internal/apis/storage"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -25,12 +26,21 @@ var supportedIPFamilies = sets.New(
 	corev1.IPv6Protocol,
 )
 
+var supportedResizePolicies = sets.New(
+	storage.ResizePolicyStatic,
+	storage.ResizePolicyExpandOnly,
+)
+
 func IsSupportedIPFamily(ipFamily corev1.IPFamily) bool {
 	return supportedIPFamilies.Has(ipFamily)
 }
 
 func ValidateIPFamily(ipFamily corev1.IPFamily, fldPath *field.Path) field.ErrorList {
 	return ValidateEnum(supportedIPFamilies, ipFamily, fldPath, "must specify ipFamily")
+}
+
+func ValidateResizePolicy(policy storage.ResizePolicy, fldPath *field.Path) field.ErrorList {
+	return ValidateEnum(supportedResizePolicies, policy, fldPath, "must specify resizePolicy")
 }
 
 func ValidateIPFamilies(ipFamilies []corev1.IPFamily, fldPath *field.Path) field.ErrorList {

--- a/internal/apis/storage/v1alpha1/defaults.go
+++ b/internal/apis/storage/v1alpha1/defaults.go
@@ -37,3 +37,9 @@ func SetDefaults_BucketStatus(status *v1alpha1.BucketStatus) {
 		status.State = v1alpha1.BucketStatePending
 	}
 }
+
+func SetDefaults_VolumeClass(volumeClass *v1alpha1.VolumeClass) {
+	if volumeClass.ResizePolicy == "" {
+		volumeClass.ResizePolicy = v1alpha1.ResizePolicyStatic
+	}
+}

--- a/internal/apis/storage/v1alpha1/defaults_test.go
+++ b/internal/apis/storage/v1alpha1/defaults_test.go
@@ -1,0 +1,36 @@
+// Copyright 2023 OnMetal authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1_test
+
+import (
+	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
+	. "github.com/onmetal/onmetal-api/internal/apis/storage/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Defaults", func() {
+	It("Should default the VolumeClass expansion policy if not set", func() {
+		class := &storagev1alpha1.VolumeClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			ResizePolicy: "",
+		}
+		SetDefaults_VolumeClass(class)
+		Expect(class.ResizePolicy).To(Equal(storagev1alpha1.ResizePolicyStatic))
+	})
+})

--- a/internal/apis/storage/v1alpha1/v1alpha1_suite_test.go
+++ b/internal/apis/storage/v1alpha1/v1alpha1_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 by the OnMetal authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestV1alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "V1alpha1 Suite")
+}

--- a/internal/apis/storage/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/storage/v1alpha1/zz_generated.conversion.go
@@ -711,6 +711,7 @@ func Convert_storage_VolumeAccess_To_v1alpha1_VolumeAccess(in *storage.VolumeAcc
 func autoConvert_v1alpha1_VolumeClass_To_storage_VolumeClass(in *v1alpha1.VolumeClass, out *storage.VolumeClass, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.Capabilities = *(*core.ResourceList)(unsafe.Pointer(&in.Capabilities))
+	out.ResizePolicy = storage.ResizePolicy(in.ResizePolicy)
 	return nil
 }
 
@@ -722,6 +723,7 @@ func Convert_v1alpha1_VolumeClass_To_storage_VolumeClass(in *v1alpha1.VolumeClas
 func autoConvert_storage_VolumeClass_To_v1alpha1_VolumeClass(in *storage.VolumeClass, out *v1alpha1.VolumeClass, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.Capabilities = *(*corev1alpha1.ResourceList)(unsafe.Pointer(&in.Capabilities))
+	out.ResizePolicy = v1alpha1.ResizePolicy(in.ResizePolicy)
 	return nil
 }
 

--- a/internal/apis/storage/v1alpha1/zz_generated.defaults.go
+++ b/internal/apis/storage/v1alpha1/zz_generated.defaults.go
@@ -32,6 +32,8 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 	scheme.AddTypeDefaultingFunc(&v1alpha1.Bucket{}, func(obj interface{}) { SetObjectDefaults_Bucket(obj.(*v1alpha1.Bucket)) })
 	scheme.AddTypeDefaultingFunc(&v1alpha1.BucketList{}, func(obj interface{}) { SetObjectDefaults_BucketList(obj.(*v1alpha1.BucketList)) })
 	scheme.AddTypeDefaultingFunc(&v1alpha1.Volume{}, func(obj interface{}) { SetObjectDefaults_Volume(obj.(*v1alpha1.Volume)) })
+	scheme.AddTypeDefaultingFunc(&v1alpha1.VolumeClass{}, func(obj interface{}) { SetObjectDefaults_VolumeClass(obj.(*v1alpha1.VolumeClass)) })
+	scheme.AddTypeDefaultingFunc(&v1alpha1.VolumeClassList{}, func(obj interface{}) { SetObjectDefaults_VolumeClassList(obj.(*v1alpha1.VolumeClassList)) })
 	scheme.AddTypeDefaultingFunc(&v1alpha1.VolumeList{}, func(obj interface{}) { SetObjectDefaults_VolumeList(obj.(*v1alpha1.VolumeList)) })
 	return nil
 }
@@ -49,6 +51,17 @@ func SetObjectDefaults_BucketList(in *v1alpha1.BucketList) {
 
 func SetObjectDefaults_Volume(in *v1alpha1.Volume) {
 	SetDefaults_VolumeStatus(&in.Status)
+}
+
+func SetObjectDefaults_VolumeClass(in *v1alpha1.VolumeClass) {
+	SetDefaults_VolumeClass(in)
+}
+
+func SetObjectDefaults_VolumeClassList(in *v1alpha1.VolumeClassList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_VolumeClass(a)
+	}
 }
 
 func SetObjectDefaults_VolumeList(in *v1alpha1.VolumeList) {

--- a/internal/apis/storage/validation/volumeclass.go
+++ b/internal/apis/storage/validation/volumeclass.go
@@ -30,6 +30,16 @@ func ValidateVolumeClass(volumeClass *storage.VolumeClass) field.ErrorList {
 
 	allErrs = append(allErrs, validateVolumeClassCapabilities(volumeClass.Capabilities, field.NewPath("capabilities"))...)
 
+	allErrs = append(allErrs, validateVolumeClassResizePolicy(volumeClass.ResizePolicy, field.NewPath("resizePolicy"))...)
+
+	return allErrs
+}
+
+func validateVolumeClassResizePolicy(policy storage.ResizePolicy, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	allErrs = append(allErrs, onmetalapivalidation.ValidateResizePolicy(policy, fldPath)...)
+
 	return allErrs
 }
 

--- a/internal/apis/storage/validation/volumeclass_test.go
+++ b/internal/apis/storage/validation/volumeclass_test.go
@@ -71,6 +71,22 @@ var _ = Describe("VolumeClass", func() {
 				InvalidField("capabilities[iops]"),
 			)),
 		),
+		Entry("valid resizePolicy",
+			&storage.VolumeClass{
+				ResizePolicy: storage.ResizePolicyStatic,
+			},
+			Not(ContainElements(
+				InvalidField("resizePolicy"),
+			)),
+		),
+		Entry("invalid resizePolicy",
+			&storage.VolumeClass{
+				ResizePolicy: "foo",
+			},
+			ContainElements(
+				NotSupportedField("resizePolicy"),
+			),
+		),
 	)
 
 	DescribeTable("ValidateVolumeClassUpdate",

--- a/internal/apis/storage/volumeclass_types.go
+++ b/internal/apis/storage/volumeclass_types.go
@@ -33,7 +33,20 @@ type VolumeClass struct {
 
 	// Capabilities describes the capabilities of a volume class
 	Capabilities core.ResourceList
+	// ResizePolicy describes the supported expansion policy of a VolumeClass.
+	// If not set default to Static expansion policy.
+	ResizePolicy ResizePolicy `json:"resizePolicy,omitempty"`
 }
+
+// ResizePolicy is a type of policy.
+type ResizePolicy string
+
+const (
+	// ResizePolicyStatic is a policy that does not allow the expansion of a Volume.
+	ResizePolicyStatic ResizePolicy = "Static"
+	// ResizePolicyExpandOnly is a policy that only allows the expansion of a Volume.
+	ResizePolicyExpandOnly ResizePolicy = "ExpandOnly"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/internal/app/apiserver/apiserver.go
+++ b/internal/app/apiserver/apiserver.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"time"
 
+	"github.com/onmetal/onmetal-api/internal/admission/plugin/volumeresize"
+
 	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
 	corev1alpha1 "github.com/onmetal/onmetal-api/api/core/v1alpha1"
 	ipamv1alpha1 "github.com/onmetal/onmetal-api/api/ipam/v1alpha1"
@@ -174,11 +176,13 @@ func (o *OnmetalAPIServerOptions) Validate(args []string) error {
 func (o *OnmetalAPIServerOptions) Complete() error {
 	machinevolumedevices.Register(o.RecommendedOptions.Admission.Plugins)
 	resourcequota.Register(o.RecommendedOptions.Admission.Plugins)
+	volumeresize.Register(o.RecommendedOptions.Admission.Plugins)
 
 	o.RecommendedOptions.Admission.RecommendedPluginOrder = append(
 		o.RecommendedOptions.Admission.RecommendedPluginOrder,
 		machinevolumedevices.PluginName,
 		resourcequota.PluginName,
+		volumeresize.PluginName,
 	)
 
 	return nil

--- a/internal/app/apiserver/apiserver.go
+++ b/internal/app/apiserver/apiserver.go
@@ -20,7 +20,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/onmetal/onmetal-api/internal/admission/plugin/volumeresize"
+	"github.com/onmetal/onmetal-api/internal/admission/plugin/volumeresizepolicy"
 
 	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
 	corev1alpha1 "github.com/onmetal/onmetal-api/api/core/v1alpha1"
@@ -176,13 +176,13 @@ func (o *OnmetalAPIServerOptions) Validate(args []string) error {
 func (o *OnmetalAPIServerOptions) Complete() error {
 	machinevolumedevices.Register(o.RecommendedOptions.Admission.Plugins)
 	resourcequota.Register(o.RecommendedOptions.Admission.Plugins)
-	volumeresize.Register(o.RecommendedOptions.Admission.Plugins)
+	volumeresizepolicy.Register(o.RecommendedOptions.Admission.Plugins)
 
 	o.RecommendedOptions.Admission.RecommendedPluginOrder = append(
 		o.RecommendedOptions.Admission.RecommendedPluginOrder,
 		machinevolumedevices.PluginName,
 		resourcequota.PluginName,
-		volumeresize.PluginName,
+		volumeresizepolicy.PluginName,
 	)
 
 	return nil


### PR DESCRIPTION
# Proposed Changes

Allow to control when a Volume can be resize by introducing a ResizePolicy field to the VolumeClass type. The first two supported modes are Static and ExpandOnly.

Fixes #731 