### PR TITLE
Update golangci-lint version in GitHub actions workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.51.1
+        version: v1.54.1


### PR DESCRIPTION
# Proposed Changes

- Update golangci-lint version from v1.51.1 to v1.54.1 in the `.github/workflows/lint.yml` file.
