### PR TITLE
Improved `orictl`

### DIFF
--- a/orictl-machine/cmd/orictl-machine/orictlmachine/common/common.go
+++ b/orictl-machine/cmd/orictl-machine/orictlmachine/common/common.go
@@ -259,7 +259,6 @@ func (o *OutputOptions) RendererOrNil() (renderer.Renderer, error) {
 
 var (
 	MachineAliases          = []string{"machines", "mach", "machs"}
-	MachineClassAliases     = []string{"machineclasses", "mc", "mcs"}
 	VolumeAliases           = []string{"volumes", "vol", "vols"}
 	NetworkInterfaceAliases = []string{"networkinterfaces", "nic", "nics"}
 )

--- a/orictl-machine/cmd/orictl-machine/orictlmachine/get/status/status.go
+++ b/orictl-machine/cmd/orictl-machine/orictlmachine/get/status/status.go
@@ -32,8 +32,7 @@ func Command(streams clicommon.Streams, clientFactory common.Factory) *cobra.Com
 	)
 
 	cmd := &cobra.Command{
-		Use:     "status",
-		Aliases: common.MachineClassAliases,
+		Use: "status",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			log := ctrl.LoggerFrom(ctx)
@@ -65,13 +64,8 @@ func Command(streams clicommon.Streams, clientFactory common.Factory) *cobra.Com
 func Run(ctx context.Context, streams clicommon.Streams, client ori.MachineRuntimeClient, render renderer.Renderer) error {
 	res, err := client.Status(ctx, &ori.StatusRequest{})
 	if err != nil {
-		return fmt.Errorf("error listing machine classes: %w", err)
+		return fmt.Errorf("error getting status: %w", err)
 	}
 
-	var machineClasses []*ori.MachineClass
-	for _, status := range res.MachineClassStatus {
-		machineClasses = append(machineClasses, status.GetMachineClass())
-	}
-
-	return render.Render(machineClasses, streams.Out)
+	return render.Render(res.MachineClassStatus, streams.Out)
 }

--- a/orictl-machine/tableconverters/status.go
+++ b/orictl-machine/tableconverters/status.go
@@ -26,25 +26,27 @@ var (
 		{Name: "Name"},
 		{Name: "CPU"},
 		{Name: "Memory"},
+		{Name: "Quantity"},
 	}
 
-	MachineClass = tableconverter.Funcs[*ori.MachineClass]{
+	MachineClassStatus = tableconverter.Funcs[*ori.MachineClassStatus]{
 		Headers: tableconverter.Headers(machineClassHeaders),
-		Rows: tableconverter.SingleRowFrom(func(class *ori.MachineClass) (api.Row, error) {
+		Rows: tableconverter.SingleRowFrom(func(status *ori.MachineClassStatus) (api.Row, error) {
 			return api.Row{
-				class.Name,
-				resource.NewMilliQuantity(class.Capabilities.CpuMillis, resource.DecimalSI).String(),
-				resource.NewQuantity(int64(class.Capabilities.MemoryBytes), resource.DecimalSI).String(),
+				status.MachineClass.Name,
+				resource.NewMilliQuantity(status.MachineClass.Capabilities.CpuMillis, resource.DecimalSI).String(),
+				resource.NewQuantity(int64(status.MachineClass.Capabilities.MemoryBytes), resource.DecimalSI).String(),
+				resource.NewQuantity(status.Quantity, resource.DecimalSI).String(),
 			}, nil
 		}),
 	}
 
-	MachineClassSlice = tableconverter.SliceFuncs[*ori.MachineClass](MachineClass)
+	MachineClassStatusSlice = tableconverter.SliceFuncs[*ori.MachineClassStatus](MachineClassStatus)
 )
 
 func init() {
 	RegistryBuilder.Register(
-		tableconverter.ToTagAndTypedAny[*ori.MachineClass](MachineClass),
-		tableconverter.ToTagAndTypedAny[[]*ori.MachineClass](MachineClassSlice),
+		tableconverter.ToTagAndTypedAny[*ori.MachineClassStatus](MachineClassStatus),
+		tableconverter.ToTagAndTypedAny[[]*ori.MachineClassStatus](MachineClassStatusSlice),
 	)
 }

--- a/orictl-volume/cmd/orictl-volume/orictlvolume/common/common.go
+++ b/orictl-volume/cmd/orictl-volume/orictlvolume/common/common.go
@@ -69,6 +69,5 @@ func NewOutputOptions() *clicommon.OutputOptions {
 }
 
 var (
-	VolumeAliases      = []string{"volumes", "vol", "vols"}
-	VolumeClassAliases = []string{"volumechineclasses", "vc", "vcs"}
+	VolumeAliases = []string{"volumes", "vol", "vols"}
 )

--- a/orictl-volume/cmd/orictl-volume/orictlvolume/get/get.go
+++ b/orictl-volume/cmd/orictl-volume/orictlvolume/get/get.go
@@ -16,8 +16,8 @@ package get
 
 import (
 	"github.com/onmetal/onmetal-api/orictl-volume/cmd/orictl-volume/orictlvolume/common"
+	"github.com/onmetal/onmetal-api/orictl-volume/cmd/orictl-volume/orictlvolume/get/status"
 	"github.com/onmetal/onmetal-api/orictl-volume/cmd/orictl-volume/orictlvolume/get/volume"
-	"github.com/onmetal/onmetal-api/orictl-volume/cmd/orictl-volume/orictlvolume/get/volumeclass"
 	clicommon "github.com/onmetal/onmetal-api/orictl/cmd"
 	"github.com/spf13/cobra"
 )
@@ -29,7 +29,7 @@ func Command(streams clicommon.Streams, clientFactory common.ClientFactory) *cob
 
 	cmd.AddCommand(
 		volume.Command(streams, clientFactory),
-		volumeclass.Command(streams, clientFactory),
+		status.Command(streams, clientFactory),
 	)
 
 	return cmd

--- a/orictl-volume/cmd/orictl-volume/orictlvolume/get/status/status.go
+++ b/orictl-volume/cmd/orictl-volume/orictlvolume/get/status/status.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package volumeclass
+package status
 
 import (
 	"context"
@@ -32,8 +32,7 @@ func Command(streams clicommon.Streams, clientFactory common.ClientFactory) *cob
 	)
 
 	cmd := &cobra.Command{
-		Use:     "volumeclass",
-		Aliases: common.VolumeClassAliases,
+		Use: "status",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			log := ctrl.LoggerFrom(ctx)
@@ -65,13 +64,8 @@ func Command(streams clicommon.Streams, clientFactory common.ClientFactory) *cob
 func Run(ctx context.Context, streams clicommon.Streams, client ori.VolumeRuntimeClient, render renderer.Renderer) error {
 	res, err := client.Status(ctx, &ori.StatusRequest{})
 	if err != nil {
-		return fmt.Errorf("error listing volume classes: %w", err)
+		return fmt.Errorf("error getting status: %w", err)
 	}
 
-	var volumeClasses []*ori.VolumeClass
-	for _, status := range res.VolumeClassStatus {
-		volumeClasses = append(volumeClasses, status.GetVolumeClass())
-	}
-
-	return render.Render(volumeClasses, streams.Out)
+	return render.Render(res.VolumeClassStatus, streams.Out)
 }

--- a/orictl-volume/tableconverters/status.go
+++ b/orictl-volume/tableconverters/status.go
@@ -18,6 +18,7 @@ import (
 	ori "github.com/onmetal/onmetal-api/ori/apis/volume/v1alpha1"
 	"github.com/onmetal/onmetal-api/orictl/api"
 	"github.com/onmetal/onmetal-api/orictl/tableconverter"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 var (
@@ -25,26 +26,28 @@ var (
 		{Name: "Name"},
 		{Name: "TPS"},
 		{Name: "IOPS"},
+		{Name: "Quantity"},
 	}
 )
 
 var (
-	VolumeClass = tableconverter.Funcs[*ori.VolumeClass]{
+	VolumeClassStatus = tableconverter.Funcs[*ori.VolumeClassStatus]{
 		Headers: tableconverter.Headers(volumeClassHeaders),
-		Rows: tableconverter.SingleRowFrom(func(class *ori.VolumeClass) (api.Row, error) {
+		Rows: tableconverter.SingleRowFrom(func(status *ori.VolumeClassStatus) (api.Row, error) {
 			return api.Row{
-				class.Name,
-				class.Capabilities.Tps,
-				class.Capabilities.Iops,
+				status.VolumeClass.Name,
+				resource.NewQuantity(status.VolumeClass.Capabilities.Tps, resource.BinarySI).String(),
+				resource.NewQuantity(status.VolumeClass.Capabilities.Iops, resource.DecimalSI).String(),
+				resource.NewQuantity(status.Quantity, resource.BinarySI).String(),
 			}, nil
 		}),
 	}
-	VolumeClassSlice = tableconverter.SliceFuncs[*ori.VolumeClass](VolumeClass)
+	VolumeClassStatusSlice = tableconverter.SliceFuncs[*ori.VolumeClassStatus](VolumeClassStatus)
 )
 
 func init() {
 	RegistryBuilder.Register(
-		tableconverter.ToTagAndTypedAny[*ori.VolumeClass](VolumeClass),
-		tableconverter.ToTagAndTypedAny[[]*ori.VolumeClass](VolumeClassSlice),
+		tableconverter.ToTagAndTypedAny[*ori.VolumeClassStatus](VolumeClassStatus),
+		tableconverter.ToTagAndTypedAny[[]*ori.VolumeClassStatus](VolumeClassStatusSlice),
 	)
 }


### PR DESCRIPTION
# Proposed Changes

- Included `Quantity` of classes in table e.g.:
```
Name                   TPS      IOPS   Quantity
general-purpose        250Mi    16k    39802288Ki
io-optimized           1000Mi   64k    39802288Ki
throughput-optimized   500Mi    500    39802288Ki
```
- Adapted `orictl-volume` to support ori.status 

