### PR TITLE
Fix `Network` re-creation in `machinebroker`

### DIFF
--- a/broker/machinebroker/networks/networks.go
+++ b/broker/machinebroker/networks/networks.go
@@ -227,6 +227,9 @@ func (e *Manager) emit(providerID string, network *networkingv1alpha1.Network, e
 	w.network = network
 	w.error = err
 	close(w.done)
+	// Remove providerID from waiters map once the emit call finishes. Otherwise, we won't be able to recreate
+	// the network if it has been deleted (e.g. via GC when the network has been released due to the lack of consumers).
+	delete(e.waitersByProviderID, providerID)
 }
 
 func (e *Manager) GetNetwork(ctx context.Context, providerID string) (*networkingv1alpha1.Network, error) {


### PR DESCRIPTION
# Proposed Changes

Remove the network provider ID from the waiters map once an emit successuflly finished. This solves the problem that in case the `Network` has been removed (e.g. via network GC controller), it is never recreated. This causes a problem when brokering `Machine` and `NIC` resources as the OwnerRef can not be set on a non existing `Network` resource.